### PR TITLE
Fix typo

### DIFF
--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -574,7 +574,7 @@ class FeedEntry(object):
 		:param type: Mimetype of the linked media.
 		:returns: Data of the enclosure element.
 		'''
-		if not uri is None:
+		if not url is None:
 			self.link( href=url, rel='enclosure', type=type, length=length )
 		return self.__rss_enclosure
 


### PR DESCRIPTION
There is a small typo in the enclosure function where you use the variable name "url" in the arguments, but then "uri" in the function for comparison.

Would also suggest that in the future, you replace "if not foo is None:" with "if not foo" as per pep8, but that's not part of this pull request.
