### PR TITLE
Fixed podcast itunes image

### DIFF
--- a/feedgen/ext/podcast.py
+++ b/feedgen/ext/podcast.py
@@ -66,7 +66,7 @@ class PodcastExtension(BaseExtension):
 
 		if self.__itunes_image:
 			image = etree.SubElement(channel, '{%s}image' % ITUNES_NS)
-			image.text = self.__itunes_image
+			image['href'] = self.__itunes_image
 
 		if self.__itunes_explicit in ('yes', 'no', 'clean'):
 			explicit = etree.SubElement(channel, '{%s}explicit' % ITUNES_NS)

--- a/feedgen/ext/podcast_entry.py
+++ b/feedgen/ext/podcast_entry.py
@@ -50,7 +50,7 @@ class PodcastEntryExtension(BaseEntryExtension):
 
 		if self.__itunes_image:
 			image = etree.SubElement(entry, '{%s}image' % ITUNES_NS)
-			image.text = self.__itunes_image
+			image['href'] = self.__itunes_image
 
 		if self.__itunes_duration:
 			duration = etree.SubElement(entry, '{%s}duration' % ITUNES_NS)


### PR DESCRIPTION
Itunes image won't work like this:

``` xml
<itunes:image>image.jpg</itunes:image>
```

The correct syntax is:

``` xml
<itunes:image href="image.jpg"/>
```

http://www.apple.com/itunes/podcasts/specs.html
