### PR TITLE
Fixed NameError: global name 'updated' is not defined

### DIFF
--- a/feedgen/feed.py
+++ b/feedgen/feed.py
@@ -444,7 +444,7 @@ class FeedGenerator(object):
 		:param lastBuildDate: The modification date.
 		:returns: Modification date as datetime.datetime
 		'''
-		return updated( lastBuildDate )
+		return self.updated( lastBuildDate )
 
 
 	def author(self, author=None, replace=False, **kwargs):


### PR DESCRIPTION
Fixes traceback
lib/python2.7/site-packages/feedgen/feed.py", line 447, in lastBuildDate
return updated( lastBuildDate )
NameError: global name 'updated' is not defined

Fixes issue #7
