### PR TITLE
Make pip install dependancies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
 		url = 'http://lkiesow.github.io/python-feedgen',
 		keywords = ['feed','ATOM','RSS','podcast'],
 		license = 'FreeBSD and LGPLv3+',
-		requires = ['lxml', 'dateutils'],
+		install_requires = ['lxml', 'dateutils'],
 		classifiers = [
 			'Development Status :: 4 - Beta',
 			'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Pip was not installing the dependancies with 'requires' in setup.py.
Using 'install_requires' instead fixes this.
