### PR TITLE
Add content namespace and semantics for RSS

### DIFF
--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -45,6 +45,7 @@ class FeedEntry(object):
 		self.__rss_category    = None
 		self.__rss_comments    = None
 		self.__rss_description = None
+		self.__rss_content     = None
 		self.__rss_enclosure   = None
 		self.__rss_guid        = None
 		self.__rss_link        = None
@@ -181,7 +182,7 @@ class FeedEntry(object):
 		:param feed: The XML element to use as parent node for the item.
 		'''
 		entry = etree.SubElement(feed, 'item')
-		if not ( self.__rss_title or self.__rss_description ):
+		if not ( self.__rss_title or self.__rss_description or self.__rss_content):
 			raise ValueError('Required fields not set')
 		if self.__rss_title:
 			title = etree.SubElement(entry, 'title')
@@ -189,9 +190,18 @@ class FeedEntry(object):
 		if self.__rss_link:
 			link = etree.SubElement(entry, 'link')
 			link.text = self.__rss_link
-		if self.__rss_description:
+		if self.__rss_description and self.__rss_content:
 			description = etree.SubElement(entry, 'description')
 			description.text = self.__rss_description
+			content = etree.SubElement(entry, '{%s}encoded' %
+									'http://purl.org/rss/1.0/modules/content/')
+			content.text = self.__rss_content
+		elif self.__rss_description:
+			description = etree.SubElement(entry, 'description')
+			description.text = self.__rss_description
+		elif self.__rss_content:
+			description = etree.SubElement(entry, 'description')
+			description.text = self.__rss_content
 		for a in self.__rss_author or []:
 			author = etree.SubElement(entry, 'author')
 			author.text = a
@@ -351,7 +361,7 @@ class FeedEntry(object):
 			self.__atom_content = {'content':content}
 			if not type is None:
 				self.__atom_content['type'] = type
-			self.__rss_description = content
+			self.__rss_content = content
 		return self.__atom_content
 
 
@@ -476,7 +486,7 @@ class FeedEntry(object):
 		If a label is present it is used for the RSS feeds. Otherwise the term is
 		used. The scheme is used for the domain attribute in RSS.
 
-		:param link:    Dict or list of dicts with data.
+		:param category:    Dict or list of dicts with data.
 		:param replace: Add or replace old data.
 		:returns: List of category data.
 		'''

--- a/feedgen/feed.py
+++ b/feedgen/feed.py
@@ -220,8 +220,9 @@ class FeedGenerator(object):
 
 		:returns: Tuple containing the feed root element and the element tree.
 		'''
-		feed    = etree.Element('rss', version='2.0',
-				nsmap={'atom':  'http://www.w3.org/2005/Atom'} )
+		feed = etree.Element('rss', version='2.0',
+				nsmap={'atom':  'http://www.w3.org/2005/Atom',
+					'content': 'http://purl.org/rss/1.0/modules/content/'} )
 		channel = etree.SubElement(feed, 'channel')
 		if not ( self.__rss_title and self.__rss_link and self.__rss_description ):
 			missing = ', '.join(([] if self.__rss_title else ['title']) + \


### PR DESCRIPTION
The RSS specification contains the [Content namespace](http://www.rssboard.org/rss-profile#namespace-elements-content) for full content feeds. This patch implements the given recommendations, or at least tries to.
