### PR TITLE
Fixes return on FeedGenerator.copyright()

### DIFF
--- a/feedgen/feed.py
+++ b/feedgen/feed.py
@@ -737,7 +737,7 @@ class FeedGenerator(object):
 		:param copyright: The copyright notice.
 		:returns: The copyright notice.
 		'''
-		return rights( copyright )
+		return self.rights( copyright )
 
 
 	def subtitle(self, subtitle=None):


### PR DESCRIPTION
Just a small glitch I ran into while working with FeedGenerator
