### PR TITLE
Feed Creation: Add a separate extension call for namespace stuff. Change...

### DIFF
--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -57,13 +57,9 @@ class FeedEntry(object):
 		self.__extensions = {}
 
 
-	def atom_entry(self, feed, extensions=True):
-		'''Insert an ATOM entry into a existing XML structure. Normally you
-		would pass the feed node of an ATOM feed XML to this function.
-
-		:param feed: The XML element to use as parent node for the element.
-		'''
-		entry = etree.SubElement(feed, 'entry')
+	def atom_entry(self, extensions=True):
+		'''Create an ATOM entry and return it.'''
+		entry = etree.Element('entry')
 		if not ( self.__atom_id and self.__atom_title and self.__atom_updated ):
 			raise ValueError('Required fields not set')
 		id      = etree.SubElement(entry, 'id')
@@ -175,13 +171,9 @@ class FeedEntry(object):
 		return entry
 
 
-	def rss_entry(self, feed, extensions=True):
-		'''Insert an RSS item into a existing XML structure. Normally you
-		would pass the channel node of an RSS feed XML to this function.
-
-		:param feed: The XML element to use as parent node for the item.
-		'''
-		entry = etree.SubElement(feed, 'item')
+	def rss_entry(self, extensions=True):
+		'''Create a RSS item and return it.'''
+		entry = etree.Element('item')
 		if not ( self.__rss_title or self.__rss_description or self.__rss_content):
 			raise ValueError('Required fields not set')
 		if self.__rss_title:
@@ -235,7 +227,7 @@ class FeedEntry(object):
 		return entry
 
 
-	
+
 	def title(self, title=None):
 		'''Get or set the title value of the entry. It should contain a human
 		readable title for the entry. Title is mandatory for both ATOM and RSS
@@ -313,7 +305,7 @@ class FeedEntry(object):
 		- *name* conveys a human-readable name for the person.
 		- *uri* contains a home page for the person.
 		- *email* contains an email address for the person.
-		
+
 		:param author:  Dict or list of dicts with author data.
 		:param replace: Add or replace old data.
 
@@ -335,7 +327,7 @@ class FeedEntry(object):
 		if not author is None:
 			if replace or self.__atom_author is None:
 				self.__atom_author = []
-			self.__atom_author += ensure_format( author, 
+			self.__atom_author += ensure_format( author,
 					set(['name', 'email', 'uri']), set(['name']))
 			self.__rss_author = []
 			for a in self.__atom_author:
@@ -402,7 +394,7 @@ class FeedEntry(object):
 		RSS also supports one enclusure element per entry which is covered by the
 		link element in ATOM feed entries. So for the RSS enclusure element the
 		last link with rel=enclosure is used.
-		
+
 		:param link:    Dict or list of dicts with data.
 		:param replace: Add or replace old data.
 		:returns: List of link data.
@@ -412,9 +404,9 @@ class FeedEntry(object):
 		if not link is None:
 			if replace or self.__atom_link is None:
 				self.__atom_link = []
-			self.__atom_link += ensure_format( link, 
+			self.__atom_link += ensure_format( link,
 					set(['href', 'rel', 'type', 'hreflang', 'title', 'length']),
-					set(['href']), 
+					set(['href']),
 					{'rel':['alternate', 'enclosure', 'related', 'self', 'via']},
 					{'rel': 'alternate'} )
 			# RSS only needs one URL. We use the first link for RSS:
@@ -495,8 +487,8 @@ class FeedEntry(object):
 		if not category is None:
 			if replace or self.__atom_category is None:
 				self.__atom_category = []
-			self.__atom_category += ensure_format( 
-					category, 
+			self.__atom_category += ensure_format(
+					category,
 					set(['term', 'scheme', 'label']),
 					set(['term']) )
 			# Map the ATOM categories to RSS categories. Use the atom:label as
@@ -525,7 +517,7 @@ class FeedEntry(object):
 		- *name* conveys a human-readable name for the person.
 		- *uri* contains a home page for the person.
 		- *email* contains an email address for the person.
-		
+
 		:param contributor: Dictionary or list of dictionaries with contributor data.
 		:param replace: Add or replace old data.
 		:returns: List of contributors as dictionaries.
@@ -535,7 +527,7 @@ class FeedEntry(object):
 		if not contributor is None:
 			if replace or self.__atom_contributor is None:
 				self.__atom_contributor = []
-			self.__atom_contributor += ensure_format( contributor, 
+			self.__atom_contributor += ensure_format( contributor,
 					set(['name', 'email', 'uri']), set(['name']))
 		return self.__atom_contributor
 
@@ -563,7 +555,7 @@ class FeedEntry(object):
 
 		return self.__atom_published
 
-	
+
 	def pubdate(self, pubDate=None):
 		'''Get or set the pubDate of the entry which indicates when the entry was
 		published. This method is just another name for the published(...)
@@ -627,7 +619,7 @@ class FeedEntry(object):
 			self.__rss_ttl = int(ttl)
 		return self.__rss_ttl
 
-	
+
 	def load_extension(self, name, atom=True, rss=True):
 		'''Load a specific extension by name.
 

--- a/feedgen/ext/base.py
+++ b/feedgen/ext/base.py
@@ -15,9 +15,12 @@
 class BaseExtension(object):
 	'''Basic FeedGenerator extension.
 	'''
+	def extend_ns(self):
+		'''Returns a dict that will be used in the namespace map for the feed.'''
+		return dict()
 
 	def extend_rss(self, feed):
-		'''Create an RSS feed xml structure containing all previously set fields.
+		'''Extend a RSS feed xml structure containing all previously set fields.
 
 		:param feed: The feed xml root element.
 		:returns: The feed root element.
@@ -26,7 +29,7 @@ class BaseExtension(object):
 
 
 	def extend_atom(self, feed):
-		'''Create an ATOM feed xml structure containing all previously set
+		'''Extend an ATOM feed xml structure containing all previously set
 		fields.
 
 		:param feed: The feed xml root element.

--- a/feedgen/ext/dc.py
+++ b/feedgen/ext/dc.py
@@ -42,6 +42,8 @@ class DcBaseExtension(BaseExtension):
 		self._dcelem_title       = None
 		self._dcelem_type        = None
 
+	def extend_ns(self):
+		return {'dc' : 'http://purl.org/dc/elements/1.1/'}
 
 	def extend_atom(self, atom_feed):
 		'''Create an Atom feed xml structure containing all previously set fields.
@@ -49,14 +51,8 @@ class DcBaseExtension(BaseExtension):
 		:returns: The feed root element
 		'''
 		DCELEMENTS_NS = 'http://purl.org/dc/elements/1.1/'
-		# Replace the root element to add the new namespace
-		nsmap = atom_feed.nsmap
-		nsmap['dc'] = DCELEMENTS_NS
-		feed = etree.Element('feed', nsmap=nsmap)
-		if '{http://www.w3.org/XML/1998/namespace}lang' in atom_feed.attrib:
-			feed.attrib['{http://www.w3.org/XML/1998/namespace}lang'] = \
-					atom_feed.attrib['{http://www.w3.org/XML/1998/namespace}lang']
-		feed[:] = atom_feed[:]
+		
+		feed = atom_feed
 
 		for elem in ['contributor', 'coverage', 'creator', 'date', 'description',
 				'language', 'publisher', 'relation', 'rights', 'source', 'subject',
@@ -83,12 +79,7 @@ class DcBaseExtension(BaseExtension):
 		:returns: Tuple containing the feed root element and the element tree.
 		'''
 		DCELEMENTS_NS = 'http://purl.org/dc/elements/1.1/'
-		# Replace the root element to add the new namespace
-		nsmap = rss_feed.nsmap
-		nsmap['dc'] = DCELEMENTS_NS
-		feed = etree.Element('rss', version='2.0', nsmap=nsmap )
-		feed[:] = rss_feed[:]
-		channel = feed[0]
+		channel = rss_feed[0]
 
 		for elem in ['contributor', 'coverage', 'creator', 'date', 'description',
 				'language', 'publisher', 'relation', 'rights', 'source', 'subject',
@@ -106,7 +97,7 @@ class DcBaseExtension(BaseExtension):
 			node = etree.SubElement(channel, '{%s}identifier' % DCELEMENTS_NS)
 			node.text = identifier
 
-		return feed
+		return rss_feed
 
 
 	def dc_contributor(self, contributor=None, replace=False):

--- a/feedgen/ext/podcast.py
+++ b/feedgen/ext/podcast.py
@@ -34,6 +34,8 @@ class PodcastExtension(BaseExtension):
 		self.__itunes_summary      = None
 
 
+	def extend_ns(self):
+		return {'itunes' : 'http://www.itunes.com/dtds/podcast-1.0.dtd'}
 
 
 	def extend_rss(self, rss_feed):
@@ -42,11 +44,7 @@ class PodcastExtension(BaseExtension):
 		:returns: Tuple containing the feed root element and the element tree.
 		'''
 		ITUNES_NS = 'http://www.itunes.com/dtds/podcast-1.0.dtd'
-		# Replace the root element to add the itunes namespace
-		nsmap = rss_feed.nsmap
-		nsmap['itunes'] = ITUNES_NS
-		feed = etree.Element('rss', version='2.0', nsmap=nsmap )
-		feed[:] = rss_feed[:]
+		feed = rss_feed
 		channel = feed[0]
 
 		if self.__itunes_author:


### PR DESCRIPTION
... extensions accordingly.

Rationale: The current approach for feed extension is a bit error prone, for example the dc extension currently erases the default namespace of atom feeds. To fix this, I propose to add an _extend_ns_ call to extensions that indicates which namespaces should be added to the feed, and to redo the feed extension call a bit (work on the given XML, don't copy, extend & return it).
This will break current extensions, so I fixed the ones that are included.

Other changes:
Entry creation: Entries create their own XML Element, which is put into the feed by the caller.
Mostly done for clarity, the entry stuff is more self-contained then.

Whitespace erasion: I changed the config of my text editor, so it deleted trailing whitespaces. I'm not sure if that's right for docstrings, I can amend that if you wish.
