### PR TITLE
Added Python2 and Python3 compatibility

### DIFF
--- a/feedgen/__main__.py
+++ b/feedgen/__main__.py
@@ -11,6 +11,14 @@
 from feedgen.feed import FeedGenerator
 import sys
 
+def print_enc(string):
+	version = sys.version_info[0]
+
+	if version == 2:
+		print(string)
+	elif version == 3:
+		sys.stdout.buffer.write(string)
+
 
 
 if __name__ == '__main__':
@@ -18,15 +26,15 @@ if __name__ == '__main__':
 			sys.argv[1].endswith('rss') \
 					or sys.argv[1].endswith('atom') \
 					or sys.argv[1].endswith('podcast') ):
-		print 'Usage: %s ( <file>.atom | atom | <file>.rss | rss | podcast )' % \
-				'pythom -m feedgen'
-		print ''
-		print '  atom        -- Generate ATOM test output and print it to stdout.'
-		print '  rss         -- Generate RSS test output and print it to stdout.'
-		print '  <file>.atom -- Generate ATOM test feed and write it to file.atom.'
-		print '  <file>.rss  -- Generate RSS test teed and write it to file.rss.'
-		print '  podcast     -- Generator Podcast test output and print it to stdout.'
-		print ''
+		print_enc ('Usage: %s ( <file>.atom | atom | <file>.rss | rss | podcast )' % \
+				'pythom -m feedgen')
+		print_enc ('')
+		print_enc ('  atom        -- Generate ATOM test output and print it to stdout.')
+		print_enc ('  rss         -- Generate RSS test output and print it to stdout.')
+		print_enc ('  <file>.atom -- Generate ATOM test feed and write it to file.atom.')
+		print_enc ('  <file>.rss  -- Generate RSS test teed and write it to file.rss.')
+		print_enc ('  podcast     -- Generator Podcast test output and print it to stdout.')
+		print_enc ('')
 		exit()
 
 	arg = sys.argv[1]
@@ -59,9 +67,9 @@ if __name__ == '__main__':
 	fe.author( name='Lars Kiesow', email='lkiesow@uos.de' )
 
 	if arg == 'atom':
-		print fg.atom_str(pretty=True)
+		print_enc (fg.atom_str(pretty=True))
 	elif arg == 'rss':
-		print fg.rss_str(pretty=True)
+		print_enc (fg.rss_str(pretty=True))
 	elif arg == 'podcast':
 		# Load the podcast extension. It will automatically be loaded for all
 		# entries in the feed, too. Thus also for our “fe”.
@@ -76,18 +84,18 @@ if __name__ == '__main__':
 				'consectetur adipiscing elit. ' + \
 				'Verba tu fingas et ea dicas, quae non sentias?')
 		fe.podcast.itunes_author('Lars Kiesow')
-		print fg.rss_str(pretty=True)
+		print_enc (fg.rss_str(pretty=True))
 
 	elif arg == 'dc.atom':
 		fg.load_extension('dc')
 		fg.dc.dc_contributor('Lars Kiesow')
 		fe.dc.dc_contributor('Lars Kiesow')
-		print fg.atom_str(pretty=True)
+		print_enc (fg.atom_str(pretty=True))
 
 	elif arg == 'dc.rss':
 		fg.load_extension('dc')
 		fg.dc.dc_contributor('Lars Kiesow')
-		print fg.rss_str(pretty=True)
+		print_enc (fg.rss_str(pretty=True))
 
 	elif arg.endswith('atom'):
 		fg.atom_file(arg)

--- a/feedgen/feed.py
+++ b/feedgen/feed.py
@@ -16,6 +16,7 @@ import dateutil.tz
 from feedgen.entry import FeedEntry
 from feedgen.util import ensure_format
 import feedgen.version
+import sys
 
 
 _feedgen_version = feedgen.version.version_str
@@ -962,8 +963,15 @@ class FeedGenerator(object):
 		if feedEntry is None:
 			feedEntry = FeedEntry()
 
+		version = sys.version_info[0]
+
+		if version == 2:
+			items = self.__extensions.iteritems()
+		else:
+			items = self.__extensions.items()
+
 		# Try to load extensions:
-		for extname,ext in self.__extensions.iteritems():
+		for extname,ext in items:
 			try:
 				feedEntry.load_extension( extname, ext['atom'], ext['rss'] )
 			except ImportError:
@@ -996,10 +1004,16 @@ class FeedGenerator(object):
 			if replace:
 				self.__feed_entries = []
 
+			version = sys.version_info[0]
+
+			if version == 2:
+				items = self.__extensions.iteritems()
+			else:
+				items = self.__extensions.items()
 
 			# Try to load extensions:
 			for e in entry:
-				for extname,ext in self.__extensions.iteritems():
+				for extname,ext in items:
 					try:
 						e.load_extension( extname, ext['atom'], ext['rss'] )
 					except ImportError:

--- a/feedgen/util.py
+++ b/feedgen/util.py
@@ -8,7 +8,7 @@
 	:copyright: 2013, Lars Kiesow <lkiesow@uos.de>
 	:license: FreeBSD and LGPL, see license.* for more details.
 '''
-
+import sys
 
 
 def ensure_format(val, allowed, required, allowed_values=None, defaults=None):
@@ -36,13 +36,27 @@ def ensure_format(val, allowed, required, allowed_values=None, defaults=None):
 		if not isinstance(elem, dict):
 			raise ValueError('Invalid data (value is no dictionary)')
 		# Set default values
-		for k,v in defaults.iteritems():
+
+		version = sys.version_info[0]
+
+		if version == 2:
+			items = defaults.iteritems()
+		else:
+			items = defaults.items()
+
+		for k,v in items:
 			elem[k] = elem.get(k, v)
 		if not set(elem.keys()) <= allowed:
 			raise ValueError('Data contains invalid keys')
 		if not set(elem.keys()) >= required:
 			raise ValueError('Data contains not all required keys')
-		for k,v in allowed_values.iteritems():
+
+		if version == 2:
+			values = allowed_values.iteritems()
+		else:
+			values = allowed_values.items()
+
+		for k,v in values:
 			if elem.get(k) and not elem[k] in v:
 				raise ValueError('Invalid value for %s' % k )
 	return val


### PR DESCRIPTION
Exchanged iteritems() for item() and added helper function for printing depending on the Python version. Use this patch as a base for further and better Python3 compatibility. python-feedgen is now working for both Python2 and Python3.
