### PR TITLE
Suggested changes to rss_entry in  feedgen/entry.py

### DIFF
--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -195,8 +195,10 @@ class FeedEntry(object):
 			description = etree.SubElement(entry, 'description')
 			description.text = self.__rss_description
 		elif self.__rss_content:
-			description = etree.SubElement(entry, 'description')
-			description.text = self.__rss_content['content']
+			content = etree.SubElement(entry, '{%s}encoded' %
+									'http://purl.org/rss/1.0/modules/content/')
+			content.text = etree.CDATA(self.__rss_content['content']) \
+				if self.__rss_content.get('type', '') == 'CDATA' else self.__rss_content['content']
 		for a in self.__rss_author or []:
 			author = etree.SubElement(entry, 'author')
 			author.text = a


### PR DESCRIPTION
When a `content` attribute is given but there is no `description`, the argument to `content` is written to xml inside `description` tags.

Using the example in `feedgen/__main__.py`, something like `fe.content("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")` would turn into `<description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</description>.`

I'm not sure if a `description` tag is required for it to be valid xml or whether it was overlooked, but I think it would be nice to have the option.  Especially when the user specifically requests that the data be written as `content`!
