### PR TITLE
Adds tox and Python 3 compatiblity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ feedgen/tests/tmp_Rssfeed.xml
 tmp_Atomfeed.xml
 
 tmp_Rssfeed.xml
+
+/.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-# command to install dependencies
-install: "pip install lxml python-dateutil" 
-# command to run tests
-script: py.test
+
+python: 2.7
+
+env:
+  - TOXENV=py26
+  - TOXENV=py27
+  - TOXENV=py32
+  - TOXENV=py33
+  - TOXENV=py34
+
+script: tox
+
+install:
+  - pip install tox
+
+script:
+  - tox

--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -13,6 +13,7 @@ from datetime import datetime
 import dateutil.parser
 import dateutil.tz
 from feedgen.util import ensure_format
+from six import string_types
 
 
 class FeedEntry(object):
@@ -282,7 +283,7 @@ class FeedEntry(object):
 		:returns: Modification date as datetime.datetime
 		'''
 		if not updated is None:
-			if isinstance(updated, basestring):
+			if isinstance(updated, string_types):
 				updated = dateutil.parser.parse(updated)
 			if not isinstance(updated, datetime):
 				raise ValueError('Invalid datetime format')
@@ -549,7 +550,7 @@ class FeedEntry(object):
 		:returns: Creation date as datetime.datetime
 		'''
 		if not published is None:
-			if isinstance(published, basestring):
+			if isinstance(published, string_types):
 				published = dateutil.parser.parse(published)
 			if not isinstance(published, datetime):
 				raise ValueError('Invalid datetime format')

--- a/feedgen/feed.py
+++ b/feedgen/feed.py
@@ -17,6 +17,7 @@ from feedgen.entry import FeedEntry
 from feedgen.util import ensure_format
 import feedgen.version
 import sys
+from six import string_types
 
 
 _feedgen_version = feedgen.version.version_str
@@ -431,7 +432,7 @@ class FeedGenerator(object):
 		:returns: Modification date as datetime.datetime
 		'''
 		if not updated is None:
-			if isinstance(updated, basestring):
+			if isinstance(updated, string_types):
 				updated = dateutil.parser.parse(updated)
 			if not isinstance(updated, datetime):
 				raise ValueError('Invalid datetime format')
@@ -670,9 +671,9 @@ class FeedGenerator(object):
 		'''
 		if not generator is None:
 			self.__atom_generator = {'value':generator}
-			if not version in None:
+			if not version is None:
 				self.__atom_generator['version'] = version
-			if not uri in None:
+			if not uri is None:
 				self.__atom_generator['uri'] = uri
 			self.__rss_generator = generator
 		return self.__atom_generator
@@ -846,7 +847,7 @@ class FeedGenerator(object):
 		:returns: Publication date as datetime.datetime
 		'''
 		if not pubDate is None:
-			if isinstance(pubDate, basestring):
+			if isinstance(pubDate, string_types):
 				pubDate = dateutil.parser.parse(pubDate)
 			if not isinstance(pubDate, datetime):
 				raise ValueError('Invalid datetime format')

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
 		url = 'http://lkiesow.github.io/python-feedgen',
 		keywords = ['feed','ATOM','RSS','podcast'],
 		license = 'FreeBSD and LGPLv3+',
-		install_requires = ['lxml', 'dateutils'],
+		install_requires = ['lxml', 'dateutils', 'six'],
 		classifiers = [
 			'Development Status :: 4 - Beta',
 			'Development Status :: 5 - Production/Stable',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist=py26, py27, py32, py33, py34
+
+[testenv]
+commands=py.test {posargs}
+deps=
+    pytest


### PR DESCRIPTION
I've hit a few Python 3 incompatibilities which I've fixed. I've also added a `tox.ini`, to run the tests more easily (using just `$ tox`). 