### PR TITLE
Fix atom content type CDATA

### DIFF
--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -104,7 +104,7 @@ class FeedEntry(object):
 							xmlns="http://www.w3.org/1999/xhtml">%s</div>''' % \
 							self.__atom_content.get('content')))
 				elif type == 'CDATA':
-					content.text = etree.CDATA(self.__atom_content)
+					content.text = etree.CDATA(self.__atom_content.get('content'))
 				# Emed the text in escaped form
 				elif not type or type.startswith('text') or type == 'html':
 					content.text = self.__atom_content.get('content')

--- a/feedgen/tests/test_entry.py
+++ b/feedgen/tests/test_entry.py
@@ -92,3 +92,15 @@ class TestSequenceFunctions(unittest.TestCase):
 
 		result = fg.rss_str()
 		assert b'domain="http://www.somedomain.com/category"' in result
+		
+	def test_content_cdata_type(self):
+		fg = FeedGenerator()
+		fg.title('some title')
+		fg.id('http://lernfunk.de/media/654322/1')
+		fe = fg.add_entry()
+		fe.id('http://lernfunk.de/media/654322/1')
+		fe.title('some title')
+		fe.content('content', type='CDATA')
+		result = fg.atom_str()
+		assert b'<content type="CDATA"><![CDATA[content]]></content>' in result
+


### PR DESCRIPTION
Right now if you select content type **CDATA** for atom feed like following:
``feed_entry.content('content', type="CDATA")``
it raises ```TypeError: Argument must be bytes or unicode, got 'dict'```.

In this PR, it's been fixed.