### PR TITLE
allowing pluggable extensions

### DIFF
--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -56,6 +56,7 @@ class FeedEntry(object):
 
 		# Extension list:
 		self.__extensions = {}
+		self.__extensions_register = {}
 
 
 	def atom_entry(self, extensions=True):
@@ -654,3 +655,43 @@ class FeedEntry(object):
 		extinst = ext()
 		setattr(self, name, extinst)
 		self.__extensions[name] = {'inst':extinst,'atom':atom,'rss':rss}
+
+	def register_extension(
+		self,
+		namespace,
+		extension_class_feed=None,
+		extension_class_entry=None,
+		atom=True,
+		rss=True
+	):
+		'''Register a specific extension by classes to a namespace.
+
+		:param namespace: namespace for the extension
+		:param extension_class_feed: Class of the feed extension to load.
+		:param extension_class_entry: Class of the entry extension to load.
+		:param atom: If the extension should be used for ATOM feeds.
+		:param rss: If the extension should be used for RSS feeds.
+		'''
+		# Check loaded extensions
+		# `load_extension` ignores the "Extension" suffix.
+		if not isinstance(self.__extensions, dict):
+			self.__extensions = {}
+		if namespace in self.__extensions.keys():
+			raise ImportError('Extension already loaded')
+
+		extinst = extension_class_entry()
+		setattr(self, namespace, extinst)
+
+		# `load_extension` registry
+		self.__extensions[namespace] = {'inst': extinst,
+										'atom': atom,
+										'rss': rss
+										}
+
+		# `register_extension` registry
+		self.__extensions_register[namespace] = {
+			'extension_class_feed': extension_class_feed,
+			'extension_class_entry': extension_class_entry,
+			'atom': atom,
+			'rss': rss,
+		}


### PR DESCRIPTION
The current Plugin system has a large fault - it will only load plugins from the feedgen/ext directory -- which means one must use a forked or patched version to support new feed or custom types.

The current system is too hardcoded to alter or replace, so I added in a second registry via `register_extension` that accepts Python classes and tracks them in a separate registry.  The various calls to `load_extension` check to see if the namespaces were loaded via `register_extension` and calls the appropriate 'load_extension' or 'register_extension'