### PR TITLE
Remove stale dateutils package and use wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
+  - "3.5"
 
 before_install: pip install --quiet lxml python-dateutil
 

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ doc-latexpdf:
 publish: sdist
 	python setup.py register sdist upload
 
+publish_wheel: sdist
+	python setup.py bdist_wheel upload
+
 test:
 	python -m unittest feedgen.tests.test_feed
 	python -m unittest feedgen.tests.test_entry

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
 		url = 'http://lkiesow.github.io/python-feedgen',
 		keywords = ['feed','ATOM','RSS','podcast'],
 		license = 'FreeBSD and LGPLv3+',
-		install_requires = ['lxml', 'dateutils'],
+		install_requires = ['lxml', 'python-dateutil'],
 		classifiers = [
 			'Development Status :: 4 - Beta',
 			'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import setuptools
 from distutils.core import setup
 import feedgen.version
 


### PR DESCRIPTION
It seems like `python-dateutil` seems to have replaced `dateutils`, the latter of which installs strange dependencies like `argparse` (stdlib since 2.6). The tests also only install `python-dateutil`, so this just makes the install dependencies equal to the test dependencies