### PR TITLE
Rename url to uri in Atom feeds for RFC 4287 compliance

### DIFF
--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -90,8 +90,8 @@ class FeedEntry(object):
 				email = etree.SubElement(author, 'email')
 				email.text = a.get('email')
 			if a.get('uri'):
-				email = etree.SubElement(author, 'url')
-				email.text = a.get('uri')
+				uri = etree.SubElement(author, 'uri')
+				uri.text = a.get('uri')
 
 		if self.__atom_content:
 			content = etree.SubElement(entry, 'content')
@@ -156,8 +156,8 @@ class FeedEntry(object):
 				email = etree.SubElement(contrib, 'email')
 				email.text = c.get('email')
 			if c.get('uri'):
-				email = etree.SubElement(contrib, 'url')
-				email.text = c.get('uri')
+				uri = etree.SubElement(contrib, 'uri')
+				uri.text = c.get('uri')
 
 		if self.__atom_published:
 			published   = etree.SubElement(entry, 'published')

--- a/feedgen/feed.py
+++ b/feedgen/feed.py
@@ -47,7 +47,7 @@ class FeedGenerator(object):
 		self.__atom_contributor = None
 		self.__atom_generator   = {
 				'value'  :'python-feedgen',
-				'url'    :'http://lkiesow.github.io/python-feedgen',
+				'uri'    :'http://lkiesow.github.io/python-feedgen',
 				'version':feedgen.version.version_str } #{value*,uri,version}
 		self.__atom_icon     = None
 		self.__atom_logo     = None
@@ -124,8 +124,8 @@ class FeedGenerator(object):
 				email = etree.SubElement(author, 'email')
 				email.text = a.get('email')
 			if a.get('uri'):
-				email = etree.SubElement(author, 'url')
-				email.text = a.get('uri')
+				uri = etree.SubElement(author, 'uri')
+				uri.text = a.get('uri')
 
 		for l in self.__atom_link or []:
 			link = etree.SubElement(feed, 'link', href=l['href'])
@@ -159,8 +159,8 @@ class FeedGenerator(object):
 				email = etree.SubElement(contrib, 'email')
 				email.text = c.get('email')
 			if c.get('uri'):
-				email = etree.SubElement(contrib, 'url')
-				email.text = c.get('uri')
+				uri = etree.SubElement(contrib, 'uri')
+				uri.text = c.get('uri')
 
 		if self.__atom_generator:
 			generator = etree.SubElement(feed, 'generator')

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -215,7 +215,7 @@ class TestSequenceFunctions(unittest.TestCase):
 		assert feed.find("{%s}subtitle" % nsAtom).text == self.subtitle
 		assert feed.find("{%s}contributor" % nsAtom).find("{%s}name" % nsAtom).text == self.contributor['name']
 		assert feed.find("{%s}contributor" % nsAtom).find("{%s}email" % nsAtom).text == self.contributor['email']
-		assert feed.find("{%s}contributor" % nsAtom).find("{%s}url" % nsAtom).text == self.contributor['uri']
+		assert feed.find("{%s}contributor" % nsAtom).find("{%s}uri" % nsAtom).text == self.contributor['uri']
 		assert feed.find("{%s}rights" % nsAtom).text == self.copyright
 
 	def test_rssFeedFile(self):


### PR DESCRIPTION
According to RFC 4287, there is no `atom:url` element, only `atom:uri`, so replace occurrences of `atom:url` with `atom:uri` for compliance.

Also rename variables holding `atom:uri` from `email` to `uri` to better indicate what they actually are.

---

Previously, generated feeds would fail the [W3 Feed Validation Service](https://validator.w3.org/feed/). A simple test script `gen.py`:

```py
#!/usr/bin/env python3
from feedgen.feed import FeedGenerator

author = {'name': 'Zhiming Wang', 'email': 'zmwangx@gmail.com', 'uri': 'https://zhimingwang.org'}

fg = FeedGenerator()
fg.id('https://zhimingwang.org/test.atom')
fg.title('Test feed')
fg.author(author)

fe = fg.add_entry()
fe.id('https://zhimingwang.org/1970/1/1/test.html')
fe.title('Test entry')
fe.author(author)
fe.content('Test piece.')

print(fg.atom_str().decode('utf-8'))
```

Pass it through the validator:

```sh
$ curl -sS -X POST --data-urlencode "rawdata=$(./gen.py)" --data-urlencode 'output=soap12' https://validator.w3.org/feed/check.cgi | xmllint --format -
```

Response:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
  <env:Body>
    <m:feedvalidationresponse xmlns:m="http://www.w3.org/2005/10/feed-validator" env:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
      <m:uri/>
      <m:checkedby>http://validator.w3.org/feed/check.cgi</m:checkedby>
      <m:date>2016-12-19T05:51:39.782184</m:date>
      <m:validity>false</m:validity>
      <m:errors>
        <m:errorcount>1</m:errorcount>
        <m:errorlist>
          <error>
            <level>error</level>
            <type>UndefinedElement</type>
            <line>2</line>
            <column>224</column>
            <text>Undefined author element: url</text>
            <msgcount>2</msgcount>
            <backupcolumn>224</backupcolumn>
            <backupline>2</backupline>
            <element>url</element>
            <parent>author</parent>
          </error>
        </m:errorlist>
      </m:errors>
      <m:warnings>
        <m:warningcount>1</m:warningcount>
        <m:warninglist>
          <warning>
            <level>warning</level>
            <type>MissingSelf</type>
            <line>2</line>
            <column>0</column>
            <text>Missing atom:link with rel="self"</text>
            <msgcount>1</msgcount>
            <backupcolumn>320</backupcolumn>
            <backupline>2</backupline>
            <element>feed</element>
            <parent>root</parent>
          </warning>
        </m:warninglist>
      </m:warnings>
      <m:informations>
        <m:infocount>0</m:infocount>
        <m:infolist/>
      </m:informations>
    </m:feedvalidationresponse>
  </env:Body>
</env:Envelope>
```

Note the error:

```
Undefined author element: url
```