### PR TITLE
new entries are inserted to the front of the __feed_entries list

### DIFF
--- a/feedgen/feed.py
+++ b/feedgen/feed.py
@@ -1030,7 +1030,7 @@ class FeedGenerator(object):
             except ImportError:
                 pass
 
-        self.__feed_entries.append(feedEntry)
+        self.__feed_entries.insert(0, feedEntry)
         return feedEntry
 
     def add_item(self, item=None):


### PR DESCRIPTION
I experienced some trouble with feed readers which expect the most recent entry be always at the beginning of the feed XML. Although it is not part of the RFC4287 it appears that it is a common consensus to start with the newest entry.

Background: A recurring process inspects my data and generates change notifications via an atom feed. The FeedGenerator is pickled and stored to disk to avoid regeneration of the whole feed on each cycle.