### PR TITLE
Unit Tests: Temporary file handles need to be closed explicitly under…

### DIFF
--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -134,13 +134,14 @@ class TestSequenceFunctions(unittest.TestCase):
 
     def test_atomFeedFile(self):
         fg = self.fg
-        _, filename = tempfile.mkstemp()
+        fh, filename = tempfile.mkstemp()
         fg.atom_file(filename=filename, pretty=True, xml_declaration=False)
 
         with open(filename, "r") as myfile:
             atomString = myfile.read().replace('\n', '')
 
         self.checkAtomString(atomString)
+        os.close(fh)
         os.remove(filename)
 
     def test_atomFeedString(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,10 +31,11 @@ class TestSequenceFunctions(unittest.TestCase):
 
     def test_file(self):
         for extemsion in '.atom', '.rss':
-            _, filename = tempfile.mkstemp(extemsion)
+            fh, filename = tempfile.mkstemp(extemsion)
             sys.argv = ['feedgen', filename]
             try:
                 __main__.main()
             except:
                 assert False
+            os.close(fh)
             os.remove(filename)


### PR DESCRIPTION
… Windows

Running the unit tests on Windows Python 3.6 x64 fails because the temporary files cannot be removed. The filehandle returned by mkstemp() is still in use and must be explicitly closed before file removal.