### PR TITLE
RSS: use the <dc:creator> tag if author's name but no email address is given

### DIFF
--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -46,6 +46,7 @@ class FeedEntry(object):
         self.__rss_category = None
         self.__rss_comments = None
         self.__rss_description = None
+        self.__rss_dcCreator = None
         self.__rss_content = None
         self.__rss_enclosure = None
         self.__rss_guid = None
@@ -207,6 +208,10 @@ class FeedEntry(object):
         for a in self.__rss_author or []:
             author = etree.SubElement(entry, 'author')
             author.text = a
+        for a in self.__rss_dcCreator or []:
+            XMLNS_DC = 'http://purl.org/dc/elements/1.1/'
+            dcCreator = etree.SubElement(entry, '{%s}creator' % XMLNS_DC)
+            dcCreator.text = a
         if self.__rss_guid:
             guid = etree.SubElement(entry, 'guid')
             guid.text = self.__rss_guid
@@ -335,9 +340,12 @@ class FeedEntry(object):
                                                 set(['name', 'email', 'uri']),
                                                 set(['name']))
             self.__rss_author = []
+            self.__rss_dcCreator = []
             for a in self.__atom_author:
                 if a.get('email'):
                     self.__rss_author.append('%(email)s (%(name)s)' % a)
+                else:
+                    self.__rss_dcCreator.append('%(name)s' %a)
         return self.__atom_author
 
     def content(self, content=None, src=None, type=None):

--- a/feedgen/feed.py
+++ b/feedgen/feed.py
@@ -252,7 +252,8 @@ class FeedGenerator(object):
                     nsmap.update(ext['inst'].extend_ns())
 
         nsmap.update({'atom':  'http://www.w3.org/2005/Atom',
-                      'content': 'http://purl.org/rss/1.0/modules/content/'})
+                      'content': 'http://purl.org/rss/1.0/modules/content/',
+                      'dc': 'http://purl.org/dc/elements/1.1/'})
 
         feed = etree.Element('rss', version='2.0', nsmap=nsmap)
         channel = etree.SubElement(feed, 'channel')

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -93,6 +93,14 @@ class TestSequenceFunctions(unittest.TestCase):
         fe.ttl(8)
         assert fe.ttl() == 8
 
+        fe = self.fg.add_item()
+        fe.title('qwe')
+        fe.description('asdfx')
+        fe.guid('123')
+        fe.updated('2017-02-05 13:26:58+01:00')
+        fe.author({'name': 'John Doe'})
+        assert author.get('name') == 'John Doe'
+
         self.fg.rss_str()
         self.fg.atom_str()
 


### PR DESCRIPTION
If the author does not want to publish his mail address but only his name, the <author> tag cannot be used according to the RSS 2.0 spec. It is recommended to use the <dc:creator> tag if only the name is given.

FeedEntry.author() is adjusted to use the __rss_dcCreator value instead of __rss_author if the "email" key is not set.