### PR TITLE
Make Author's Name Optional

### DIFF
--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -333,11 +333,14 @@ class FeedEntry(object):
                 self.__atom_author = []
             self.__atom_author += ensure_format(author,
                                                 set(['name', 'email', 'uri']),
-                                                set(['name']))
+                                                set())
             self.__rss_author = []
             for a in self.__atom_author:
                 if a.get('email'):
-                    self.__rss_author.append('%(email)s (%(name)s)' % a)
+                    if a.get('name'):
+                        self.__rss_author.append('%(email)s (%(name)s)' % a)
+                    else:
+                        self.__rss_author.append('%(email)s' % a)
         return self.__atom_author
 
     def content(self, content=None, src=None, type=None):

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -63,7 +63,11 @@ class TestSequenceFunctions(unittest.TestCase):
         fe = self.fg.add_item()
         fe.title('qwe')
         assert fe.title() == 'qwe'
-        author = fe.author(name='John Doe', email='jdoe@example.com')[0]
+        author = fe.author(email='ldoe@example.com')[0]
+        assert not author.get('name')
+        assert author.get('email') == 'ldoe@example.com'
+        author = fe.author(name='John Doe', email='jdoe@example.com',
+                           replace=True)[0]
         assert author.get('name') == 'John Doe'
         assert author.get('email') == 'jdoe@example.com'
         contributor = fe.contributor(name='John Doe', email='jdoe@ex.com')[0]


### PR DESCRIPTION
RSS does not require an author's name, but only his email address. This
patch makes the name optional for RSS. Note that the name is required in
ATOM feeds and an author will not be included if the name is missing.

This fixes #59