### PR TITLE
added order parameter to add_entry()

### DIFF
--- a/feedgen/feed.py
+++ b/feedgen/feed.py
@@ -995,12 +995,15 @@ class FeedGenerator(object):
             self.__rss_webMaster = webMaster
         return self.__rss_webMaster
 
-    def add_entry(self, feedEntry=None):
+    def add_entry(self, feedEntry=None, order='prepend'):
         '''This method will add a new entry to the feed. If the feedEntry
         argument is omittet a new Entry object is created automatically. This
         is the prefered way to add new entries to a feed.
 
         :param feedEntry: FeedEntry object to add.
+        :param order: If `prepend` is chosen, the entry will be inserted
+                      at the beginning of the feed. If `append` is chosen,
+                      the entry will be appended to the feed. (default: `prepend`).
         :returns: FeedEntry object created or passed to this function.
 
         Example::
@@ -1030,7 +1033,10 @@ class FeedGenerator(object):
             except ImportError:
                 pass
 
-        self.__feed_entries.insert(0, feedEntry)
+	if order == 'prepend':
+	        self.__feed_entries.insert(0, feedEntry)
+	else:
+		self.__feed_entries.append(feedEntry)
         return feedEntry
 
     def add_item(self, item=None):


### PR DESCRIPTION
Commit 770603320032a6afc7e82b27bcb4926468fa22d8 changed the order
in which new entries are added to a feed without warning.

This commit allows the user to choose the order herself. This is important,
e.g. when creating custom podcast feeds.