### PR TITLE
Consistent method naming

### DIFF
--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 import dateutil.parser
 import dateutil.tz
+import warnings
 from lxml import etree
 
 from feedgen.compat import string_types
@@ -569,11 +570,23 @@ class FeedEntry(object):
 
         return self.__atom_published
 
-    def pubdate(self, pubDate=None):
+    def pubDate(self, pubDate=None):
         '''Get or set the pubDate of the entry which indicates when the entry
         was published. This method is just another name for the published(...)
         method.
         '''
+        return self.published(pubDate)
+
+    def pubdate(self, pubDate=None):
+        '''Get or set the pubDate of the entry which indicates when the entry
+        was published. This method is just another name for the published(...)
+        method.
+
+        pubdate(…) is deprected and may be removed in feedgen ≥ 0.8. Use
+        pubDate(…) instead.
+        '''
+        warnings.warn('pubdate(…) is deprected and may be removed in feedgen '
+                      '≥ 0.8. Use pubDate(…) instead.')
         return self.published(pubDate)
 
     def rights(self, rights=None):

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -87,8 +87,8 @@ class TestSequenceFunctions(unittest.TestCase):
         assert fe.summary() == 'asdf'
         fe.description('asdfx')
         assert fe.description() == 'asdfx'
-        fe.pubdate('2017-02-05 13:26:58+01:00')
-        assert fe.pubdate().year == 2017
+        fe.pubDate('2017-02-05 13:26:58+01:00')
+        assert fe.pubDate().year == 2017
         fe.rights('asdfx')
         assert fe.rights() == 'asdfx'
         fe.comments('asdfx')


### PR DESCRIPTION
This patch renames the entries `pubdate` method to `pubDate` to be
consistent with the feed's method as well as the documentation. Note
that for now, the old method is preserved as well but is marked as
deprecated and to be removed.

This fixes #71