### PR TITLE
Fix a few typos.

### DIFF
--- a/feedgen/__init__.py
+++ b/feedgen/__init__.py
@@ -16,7 +16,7 @@
     Create a Feed
     -------------
 
-    To create a feed simply instanciate the FeedGenerator class and insert some
+    To create a feed simply instantiate the FeedGenerator class and insert some
     data::
 
         >>> from feedgen.feed import FeedGenerator

--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -582,10 +582,10 @@ class FeedEntry(object):
         was published. This method is just another name for the published(...)
         method.
 
-        pubdate(…) is deprected and may be removed in feedgen ≥ 0.8. Use
+        pubdate(…) is deprecated and may be removed in feedgen ≥ 0.8. Use
         pubDate(…) instead.
         '''
-        warnings.warn('pubdate(…) is deprected and may be removed in feedgen '
+        warnings.warn('pubdate(…) is deprecated and may be removed in feedgen '
                       '≥ 0.8. Use pubDate(…) instead.')
         return self.published(pubDate)
 

--- a/feedgen/ext/dc.py
+++ b/feedgen/ext/dc.py
@@ -265,7 +265,7 @@ class DcBaseExtension(BaseExtension):
         return self._dcelem_publisher
 
     def dc_relation(self, relation=None, replace=False):
-        '''Get or set the dc:relation which describes a related ressource.
+        '''Get or set the dc:relation which describes a related resource.
 
         For more information see:
         http://dublincore.org/documents/dcmi-terms/#elements-relation

--- a/readme.rst
+++ b/readme.rst
@@ -32,7 +32,7 @@ Installation
 **Prebuild packages**
 
 If you are running Fedora Linux, RedHat Enterprise Linux, CentOS or Scientific
-Linux you can use the RPM Copr repostiory:
+Linux you can use the RPM Copr repository:
 
 http://copr.fedoraproject.org/coprs/lkiesow/python-feedgen/
 
@@ -56,7 +56,7 @@ You can also use pip to install the feedgen module. Simply run::
 Create a Feed
 -------------
 
-To create a feed simply instanciate the FeedGenerator class and insert some
+To create a feed simply instantiate the FeedGenerator class and insert some
 data::
 
     >>> from feedgen.feed import FeedGenerator


### PR DESCRIPTION
This fixes a few typos found in the source/documentation:

deprected → deprecated
instanciate → instantiate
repostiory → repository
ressource → resource