### PR TITLE
Add support for html summaries for Atom feeds

### DIFF
--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -49,7 +49,7 @@ def _add_text_elm(entry, data, name):
                 data[name]))
         # Everything else should be included base64 encoded
         else:
-            raise ValueError(
+            raise NotImplementedError(
                 'base64 encoded {} is not supported at the moment. '
                 'Pull requests adding support are welcome.'.format(name)
             )

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -84,7 +84,7 @@ class TestSequenceFunctions(unittest.TestCase):
         fe.updated('2017-02-05 13:26:58+01:00')
         assert fe.updated().year == 2017
         fe.summary('asdf')
-        assert fe.summary() == 'asdf'
+        assert fe.summary() == {'summary': 'asdf'}
         fe.description('asdfx')
         assert fe.description() == 'asdfx'
         fe.pubDate('2017-02-05 13:26:58+01:00')
@@ -164,3 +164,16 @@ class TestSequenceFunctions(unittest.TestCase):
         fe.content('content', type='CDATA')
         result = fg.atom_str()
         assert b'<content type="CDATA"><![CDATA[content]]></content>' in result
+
+    def test_summary_html_type(self):
+        fg = FeedGenerator()
+        fg.title('some title')
+        fg.id('http://lernfunk.de/media/654322/1')
+        fe = fg.add_entry()
+        fe.id('http://lernfunk.de/media/654322/1')
+        fe.title('some title')
+        fe.link(href='http://lernfunk.de/media/654322/1')
+        fe.summary('<p>summary</p>', type='html')
+        result = fg.atom_str()
+        expected = b'<summary type="html">&lt;p&gt;summary&lt;/p&gt;</summary>'
+        assert expected in result


### PR DESCRIPTION
Refactors out the code that was used to process the Atom content and uses it for both the content and the summary. Also adds a `type` param to the `summary` function.