### PR TITLE
Make Generator Optional (Atom)

### DIFF
--- a/feedgen/feed.py
+++ b/feedgen/feed.py
@@ -165,7 +165,7 @@ class FeedGenerator(object):
                 uri = etree.SubElement(contrib, 'uri')
                 uri.text = c.get('uri')
 
-        if self.__atom_generator:
+        if self.__atom_generator and self.__atom_generator.get('value'):
             generator = etree.SubElement(feed, 'generator')
             generator.text = self.__atom_generator['value']
             if self.__atom_generator.get('uri'):


### PR DESCRIPTION
This patch makes the field generator optional in Atom, allowing to set
an empty string to disable the element in the same way it is disabled in
RSS already:

```python
 # disable generator element
 fg.generator('')
```

This fixes #89