### PR TITLE
Use Unittest Asserts

### DIFF
--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -44,8 +44,8 @@ class TestSequenceFunctions(unittest.TestCase):
     def test_setEntries(self):
         fg2 = FeedGenerator()
         fg2.entry(self.fg.entry())
-        assert len(fg2.entry()) == 3
-        assert self.fg.entry() == fg2.entry()
+        self.assertEqual(len(fg2.entry()), 3)
+        self.assertEqual(self.fg.entry(), fg2.entry())
 
     def test_loadExtension(self):
         fe = self.fg.add_item()
@@ -53,64 +53,64 @@ class TestSequenceFunctions(unittest.TestCase):
         fe.title(u'…')
         fe.content(u'…')
         fe.load_extension('base')
-        assert fe.base
-        assert self.fg.atom_str()
+        self.assertTrue(fe.base)
+        self.assertTrue(self.fg.atom_str())
 
     def test_checkEntryNumbers(self):
         fg = self.fg
-        assert len(fg.entry()) == 3
+        self.assertEqual(len(fg.entry()), 3)
 
     def test_TestEntryItems(self):
         fe = self.fg.add_item()
         fe.title('qwe')
-        assert fe.title() == 'qwe'
+        self.assertEqual(fe.title(), 'qwe')
         author = fe.author(email='ldoe@example.com')[0]
-        assert not author.get('name')
-        assert author.get('email') == 'ldoe@example.com'
+        self.assertFalse(author.get('name'))
+        self.assertEqual(author.get('email'), 'ldoe@example.com')
         author = fe.author(name='John Doe', email='jdoe@example.com',
                            replace=True)[0]
-        assert author.get('name') == 'John Doe'
-        assert author.get('email') == 'jdoe@example.com'
+        self.assertEqual(author.get('name'), 'John Doe')
+        self.assertEqual(author.get('email'), 'jdoe@example.com')
         contributor = fe.contributor(name='John Doe', email='jdoe@ex.com')[0]
-        assert contributor == fe.contributor()[0]
-        assert contributor.get('name') == 'John Doe'
-        assert contributor.get('email') == 'jdoe@ex.com'
+        self.assertEqual(contributor, fe.contributor()[0])
+        self.assertEqual(contributor.get('name'), 'John Doe')
+        self.assertEqual(contributor.get('email'), 'jdoe@ex.com')
         link = fe.link(href='http://lkiesow.de', rel='alternate')[0]
-        assert link == fe.link()[0]
-        assert link.get('href') == 'http://lkiesow.de'
-        assert link.get('rel') == 'alternate'
+        self.assertEqual(link, fe.link()[0])
+        self.assertEqual(link.get('href'), 'http://lkiesow.de')
+        self.assertEqual(link.get('rel'), 'alternate')
         fe.guid('123')
-        assert fe.guid().get('guid') == '123'
+        self.assertEqual(fe.guid().get('guid'), '123')
         fe.updated('2017-02-05 13:26:58+01:00')
-        assert fe.updated().year == 2017
+        self.assertEqual(fe.updated().year, 2017)
         fe.summary('asdf')
-        assert fe.summary() == {'summary': 'asdf'}
+        self.assertEqual(fe.summary(), {'summary': 'asdf'})
         fe.description('asdfx')
-        assert fe.description() == 'asdfx'
+        self.assertEqual(fe.description(), 'asdfx')
         fe.pubDate('2017-02-05 13:26:58+01:00')
-        assert fe.pubDate().year == 2017
+        self.assertEqual(fe.pubDate().year, 2017)
         fe.rights('asdfx')
-        assert fe.rights() == 'asdfx'
+        self.assertEqual(fe.rights(), 'asdfx')
         source = fe.source(url='https://example.com', title='Test')
-        assert source.get('title') == 'Test'
-        assert source.get('url') == 'https://example.com'
+        self.assertEqual(source.get('title'), 'Test')
+        self.assertEqual(source.get('url'), 'https://example.com')
         fe.comments('asdfx')
-        assert fe.comments() == 'asdfx'
+        self.assertEqual(fe.comments(), 'asdfx')
         fe.enclosure(url='http://lkiesow.de', type='text/plain', length='1')
-        assert fe.enclosure().get('url') == 'http://lkiesow.de'
+        self.assertEqual(fe.enclosure().get('url'), 'http://lkiesow.de')
         fe.ttl(8)
-        assert fe.ttl() == 8
+        self.assertEqual(fe.ttl(), 8)
 
         self.fg.rss_str()
         self.fg.atom_str()
 
     def test_checkItemNumbers(self):
         fg = self.fg
-        assert len(fg.item()) == 3
+        self.assertEqual(len(fg.item()), 3)
 
     def test_checkEntryContent(self):
         fg = self.fg
-        assert fg.entry()
+        self.assertTrue(fg.entry())
 
     def test_removeEntryByIndex(self):
         fg = FeedGenerator()
@@ -120,9 +120,9 @@ class TestSequenceFunctions(unittest.TestCase):
         fe = fg.add_entry()
         fe.id('http://lernfunk.de/media/654321/1')
         fe.title('The Third Episode')
-        assert len(fg.entry()) == 1
+        self.assertEqual(len(fg.entry()), 1)
         fg.remove_entry(0)
-        assert len(fg.entry()) == 0
+        self.assertEqual(len(fg.entry()), 0)
 
     def test_removeEntryByEntry(self):
         fg = FeedGenerator()
@@ -133,9 +133,9 @@ class TestSequenceFunctions(unittest.TestCase):
         fe.id('http://lernfunk.de/media/654321/1')
         fe.title('The Third Episode')
 
-        assert len(fg.entry()) == 1
+        self.assertEqual(len(fg.entry()), 1)
         fg.remove_entry(fe)
-        assert len(fg.entry()) == 0
+        self.assertEqual(len(fg.entry()), 0)
 
     def test_categoryHasDomain(self):
         fg = FeedGenerator()
@@ -147,12 +147,12 @@ class TestSequenceFunctions(unittest.TestCase):
         fe.title('some title')
         fe.category([
              {'term': 'category',
-              'scheme': 'http://www.somedomain.com/category',
+              'scheme': 'http://somedomain.com/category',
               'label': 'Category',
               }])
 
         result = fg.rss_str()
-        assert b'domain="http://www.somedomain.com/category"' in result
+        self.assertIn(b'domain="http://somedomain.com/category"', result)
 
     def test_content_cdata_type(self):
         fg = FeedGenerator()
@@ -163,7 +163,8 @@ class TestSequenceFunctions(unittest.TestCase):
         fe.title('some title')
         fe.content('content', type='CDATA')
         result = fg.atom_str()
-        assert b'<content type="CDATA"><![CDATA[content]]></content>' in result
+        expected = b'<content type="CDATA"><![CDATA[content]]></content>'
+        self.assertIn(expected, result)
 
     def test_summary_html_type(self):
         fg = FeedGenerator()
@@ -176,4 +177,4 @@ class TestSequenceFunctions(unittest.TestCase):
         fe.summary('<p>summary</p>', type='html')
         result = fg.atom_str()
         expected = b'<summary type="html">&lt;p&gt;summary&lt;/p&gt;</summary>'
-        assert expected in result
+        self.assertIn(expected, result)

--- a/tests/test_extensions/test_dc.py
+++ b/tests/test_extensions/test_dc.py
@@ -24,8 +24,8 @@ class TestExtensionDc(unittest.TestCase):
             if method.startswith('dc_'):
                 m = getattr(self.fg.dc, method)
                 m(method)
-                assert m() == [method]
+                self.assertEqual(m(), [method])
 
         self.fg.id('123')
-        assert self.fg.atom_str()
-        assert self.fg.rss_str()
+        self.assertTrue(self.fg.atom_str())
+        self.assertTrue(self.fg.rss_str())

--- a/tests/test_extensions/test_geo.py
+++ b/tests/test_extensions/test_geo.py
@@ -403,8 +403,9 @@ class TestExtensionGeo(unittest.TestCase):
             # Trigger a warning.
             fe.geo.geom_from_geo_interface(self.polygon_with_interior)
             # Verify some things
-            assert len(w) == 1
-            assert issubclass(w[-1].category, GeoRSSPolygonInteriorWarning)
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category,
+                                       GeoRSSPolygonInteriorWarning))
 
         self.assertEqual(fe.geo.polygon(), str(self.polygon_with_interior))
 

--- a/tests/test_extensions/test_media.py
+++ b/tests/test_extensions/test_media.py
@@ -32,21 +32,21 @@ class TestExtensionMedia(unittest.TestCase):
         root = etree.fromstring(self.fg.rss_str())
         url = root.xpath('/rss/channel/item/media:group/media:content[1]/@url',
                          namespaces=ns)
-        assert url == ['file1.xy', 'file1.xy']
+        self.assertEqual(url, ['file1.xy', 'file1.xy'])
 
         # There is one without a group
         url = root.xpath('/rss/channel/item/media:content[1]/@url',
                          namespaces=ns)
-        assert url == ['file.xy']
+        self.assertEqual(url, ['file.xy'])
 
         # Check that we have the item in the resulting Atom feed
         root = etree.fromstring(self.fg.atom_str())
         url = root.xpath('/a:feed/a:entry/media:group/media:content[1]/@url',
                          namespaces=ns)
-        assert url == ['file1.xy', 'file1.xy']
+        self.assertEqual(url, ['file1.xy', 'file1.xy'])
 
         fe.media.content(content=[], replace=True)
-        assert fe.media.content() == []
+        self.assertEqual(fe.media.content(), [])
 
     def test_media_thumbnail(self):
         fe = self.fg.add_item()
@@ -66,18 +66,18 @@ class TestExtensionMedia(unittest.TestCase):
         url = root.xpath(
                 '/rss/channel/item/media:group/media:thumbnail[1]/@url',
                 namespaces=ns)
-        assert url == ['file1.xy', 'file1.xy']
+        self.assertEqual(url, ['file1.xy', 'file1.xy'])
 
         # There is one without a group
         url = root.xpath('/rss/channel/item/media:thumbnail[1]/@url',
                          namespaces=ns)
-        assert url == ['file.xy']
+        self.assertEqual(url, ['file.xy'])
 
         # Check that we have the item in the resulting Atom feed
         root = etree.fromstring(self.fg.atom_str())
         url = root.xpath('/a:feed/a:entry/media:group/media:thumbnail[1]/@url',
                          namespaces=ns)
-        assert url == ['file1.xy', 'file1.xy']
+        self.assertEqual(url, ['file1.xy', 'file1.xy'])
 
         fe.media.thumbnail(thumbnail=[], replace=True)
-        assert fe.media.thumbnail() == []
+        self.assertEqual(fe.media.thumbnail(), [])

--- a/tests/test_extensions/test_podcast.py
+++ b/tests/test_extensions/test_podcast.py
@@ -26,8 +26,8 @@ class TestExtensionPodcast(unittest.TestCase):
         cat = root.xpath('/rss/channel/itunes:category/@text', namespaces=ns)
         scat = root.xpath('/rss/channel/itunes:category/itunes:category/@text',
                           namespaces=ns)
-        assert cat[0] == 'Technology'
-        assert scat[0] == 'Podcasting'
+        self.assertEqual(cat[0], 'Technology')
+        self.assertEqual(scat[0], 'Podcasting')
 
     def test_category(self):
         self.fg.podcast.itunes_category('Technology', 'Podcasting')
@@ -40,8 +40,8 @@ class TestExtensionPodcast(unittest.TestCase):
         cat = root.xpath('/rss/channel/itunes:category/@text', namespaces=ns)
         scat = root.xpath('/rss/channel/itunes:category/itunes:category/@text',
                           namespaces=ns)
-        assert cat[0] == 'Technology'
-        assert scat[0] == 'Podcasting'
+        self.assertEqual(cat[0], 'Technology')
+        self.assertEqual(scat[0], 'Podcasting')
 
     def test_podcastItems(self):
         fg = self.fg
@@ -53,20 +53,20 @@ class TestExtensionPodcast(unittest.TestCase):
         fg.podcast.itunes_subtitle('x')
         fg.podcast.itunes_summary('x')
         fg.podcast.itunes_type('episodic')
-        assert fg.podcast.itunes_author() == 'Lars Kiesow'
-        assert fg.podcast.itunes_block() == 'x'
-        assert fg.podcast.itunes_complete() == 'no'
-        assert fg.podcast.itunes_explicit() == 'no'
-        assert fg.podcast.itunes_image() == 'x.png'
-        assert fg.podcast.itunes_subtitle() == 'x'
-        assert fg.podcast.itunes_summary() == 'x'
-        assert fg.podcast.itunes_type() == 'episodic'
+        self.assertEqual(fg.podcast.itunes_author(), 'Lars Kiesow')
+        self.assertEqual(fg.podcast.itunes_block(), 'x')
+        self.assertEqual(fg.podcast.itunes_complete(), 'no')
+        self.assertEqual(fg.podcast.itunes_explicit(), 'no')
+        self.assertEqual(fg.podcast.itunes_image(), 'x.png')
+        self.assertEqual(fg.podcast.itunes_subtitle(), 'x')
+        self.assertEqual(fg.podcast.itunes_summary(), 'x')
+        self.assertEqual(fg.podcast.itunes_type(), 'episodic')
 
         # Check that we have the item in the resulting XML
         ns = {'itunes': 'http://www.itunes.com/dtds/podcast-1.0.dtd'}
         root = etree.fromstring(self.fg.rss_str())
         author = root.xpath('/rss/channel/itunes:author/text()', namespaces=ns)
-        assert author == ['Lars Kiesow']
+        self.assertEqual(author, ['Lars Kiesow'])
 
     def test_podcastEntryItems(self):
         fe = self.fg.add_item()
@@ -84,23 +84,23 @@ class TestExtensionPodcast(unittest.TestCase):
         fe.podcast.itunes_episode(1)
         fe.podcast.itunes_title('Podcast Title')
         fe.podcast.itunes_episode_type('full')
-        assert fe.podcast.itunes_author() == 'Lars Kiesow'
-        assert fe.podcast.itunes_block() == 'x'
-        assert fe.podcast.itunes_duration() == '00:01:30'
-        assert fe.podcast.itunes_explicit() == 'no'
-        assert fe.podcast.itunes_image() == 'x.png'
-        assert fe.podcast.itunes_is_closed_captioned()
-        assert fe.podcast.itunes_order() == 1
-        assert fe.podcast.itunes_subtitle() == 'x'
-        assert fe.podcast.itunes_summary() == 'x'
-        assert fe.podcast.itunes_season() == 1
-        assert fe.podcast.itunes_episode() == 1
-        assert fe.podcast.itunes_title() == 'Podcast Title'
-        assert fe.podcast.itunes_episode_type() == 'full'
+        self.assertEqual(fe.podcast.itunes_author(), 'Lars Kiesow')
+        self.assertEqual(fe.podcast.itunes_block(), 'x')
+        self.assertEqual(fe.podcast.itunes_duration(), '00:01:30')
+        self.assertEqual(fe.podcast.itunes_explicit(), 'no')
+        self.assertEqual(fe.podcast.itunes_image(), 'x.png')
+        self.assertTrue(fe.podcast.itunes_is_closed_captioned())
+        self.assertEqual(fe.podcast.itunes_order(), 1)
+        self.assertEqual(fe.podcast.itunes_subtitle(), 'x')
+        self.assertEqual(fe.podcast.itunes_summary(), 'x')
+        self.assertEqual(fe.podcast.itunes_season(), 1)
+        self.assertEqual(fe.podcast.itunes_episode(), 1)
+        self.assertEqual(fe.podcast.itunes_title(), 'Podcast Title')
+        self.assertEqual(fe.podcast.itunes_episode_type(), 'full')
 
         # Check that we have the item in the resulting XML
         ns = {'itunes': 'http://www.itunes.com/dtds/podcast-1.0.dtd'}
         root = etree.fromstring(self.fg.rss_str())
         author = root.xpath('/rss/channel/item/itunes:author/text()',
                             namespaces=ns)
-        assert author == ['Lars Kiesow']
+        self.assertEqual(author, ['Lars Kiesow'])

--- a/tests/test_extensions/test_syndication.py
+++ b/tests/test_extensions/test_syndication.py
@@ -22,7 +22,7 @@ class TestExtensionSyndication(unittest.TestCase):
             root = etree.fromstring(self.fg.rss_str())
             a = root.xpath('/rss/channel/sy:UpdatePeriod',
                            namespaces=self.SYN_NS)
-            assert a[0].text == period_type
+            self.assertEqual(a[0].text, period_type)
 
     def test_update_frequency(self):
         for frequency in (1, 100, 2000, 100000):
@@ -30,11 +30,11 @@ class TestExtensionSyndication(unittest.TestCase):
             root = etree.fromstring(self.fg.rss_str())
             a = root.xpath('/rss/channel/sy:UpdateFrequency',
                            namespaces=self.SYN_NS)
-            assert a[0].text == str(frequency)
+            self.assertEqual(a[0].text, str(frequency))
 
     def test_update_base(self):
         base = '2000-01-01T12:00+00:00'
         self.fg.syndication.update_base(base)
         root = etree.fromstring(self.fg.rss_str())
         a = root.xpath('/rss/channel/sy:UpdateBase', namespaces=self.SYN_NS)
-        assert a[0].text == base
+        self.assertEqual(a[0].text, base)

--- a/tests/test_extensions/test_torrent.py
+++ b/tests/test_extensions/test_torrent.py
@@ -23,16 +23,16 @@ class TestExtensionTorrent(unittest.TestCase):
         fe.torrent.seeds('1')
         fe.torrent.peers('2')
         fe.torrent.verified('1')
-        assert fe.torrent.filename() == 'file.xy'
-        assert fe.torrent.infohash() == '123'
-        assert fe.torrent.contentlength() == '23'
-        assert fe.torrent.seeds() == '1'
-        assert fe.torrent.peers() == '2'
-        assert fe.torrent.verified() == '1'
+        self.assertEqual(fe.torrent.filename(), 'file.xy')
+        self.assertEqual(fe.torrent.infohash(), '123')
+        self.assertEqual(fe.torrent.contentlength(), '23')
+        self.assertEqual(fe.torrent.seeds(), '1')
+        self.assertEqual(fe.torrent.peers(), '2')
+        self.assertEqual(fe.torrent.verified(), '1')
 
         # Check that we have the item in the resulting XML
         ns = {'torrent': 'http://xmlns.ezrss.it/0.1/dtd/'}
         root = etree.fromstring(self.fg.rss_str())
         filename = root.xpath('/rss/channel/item/torrent:filename/text()',
                               namespaces=ns)
-        assert filename == ['file.xy']
+        self.assertEqual(filename, ['file.xy'])

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -117,22 +117,22 @@ class TestSequenceFunctions(unittest.TestCase):
     def test_baseFeed(self):
         fg = self.fg
 
-        assert fg.id() == self.feedId
-        assert fg.title() == self.title
+        self.assertEqual(fg.id(), self.feedId)
+        self.assertEqual(fg.title(), self.title)
 
-        assert fg.author()[0]['name'] == self.authorName
-        assert fg.author()[0]['email'] == self.authorMail
+        self.assertEqual(fg.author()[0]['name'], self.authorName)
+        self.assertEqual(fg.author()[0]['email'], self.authorMail)
 
-        assert fg.link()[0]['href'] == self.linkHref
-        assert fg.link()[0]['rel'] == self.linkRel
+        self.assertEqual(fg.link()[0]['href'], self.linkHref)
+        self.assertEqual(fg.link()[0]['rel'], self.linkRel)
 
-        assert fg.logo() == self.logo
-        assert fg.subtitle() == self.subtitle
+        self.assertEqual(fg.logo(), self.logo)
+        self.assertEqual(fg.subtitle(), self.subtitle)
 
-        assert fg.link()[1]['href'] == self.link2Href
-        assert fg.link()[1]['rel'] == self.link2Rel
+        self.assertEqual(fg.link()[1]['href'], self.link2Href)
+        self.assertEqual(fg.link()[1]['rel'], self.link2Rel)
 
-        assert fg.language() == self.language
+        self.assertEqual(fg.language(), self.language)
 
     def test_atomFeedFile(self):
         fg = self.fg
@@ -178,10 +178,10 @@ class TestSequenceFunctions(unittest.TestCase):
         nsAtom = self.nsAtom
         feed_links = feed.findall("{%s}link" % nsAtom)
         idx = 0
-        assert len(links) == len(feed_links)
+        self.assertEqual(len(links), len(feed_links))
         while idx < len(values_for_rel):
-            assert feed_links[idx].get('href') == links[idx]['href']
-            assert feed_links[idx].get('rel') == links[idx]['rel']
+            self.assertEqual(feed_links[idx].get('href'), links[idx]['href'])
+            self.assertEqual(feed_links[idx].get('rel'), links[idx]['rel'])
             idx += 1
 
     def test_rel_values_for_rss(self):
@@ -212,49 +212,85 @@ class TestSequenceFunctions(unittest.TestCase):
 
         atom_links = channel.findall("{%s}link" % nsAtom)
         # rss feed only implements atom's 'self' link
-        assert len(atom_links) == 1
-        assert atom_links[0].get('href') == '%s/%s' % (self.linkHref, 'self')
-        assert atom_links[0].get('rel') == 'self'
+        self.assertEqual(len(atom_links), 1)
+        self.assertEqual(atom_links[0].get('href'),
+                         '%s/%s' % (self.linkHref, 'self'))
+        self.assertEqual(atom_links[0].get('rel'), 'self')
 
         rss_links = channel.findall('link')
         # RSS only needs one URL. We use the first link for RSS:
-        assert len(rss_links) == 1
-        assert rss_links[0].text == '%s/%s' % \
-            (self.linkHref, 'working-copy-of'.replace('-', '_'))
+        self.assertEqual(len(rss_links), 1)
+        self.assertEqual(
+                rss_links[0].text,
+                '%s/%s' % (self.linkHref, 'working-copy-of'.replace('-', '_')))
 
     def checkAtomString(self, atomString):
 
         feed = etree.fromstring(atomString)
 
-        nsAtom = self.nsAtom
+        nsAtom = "{" + self.nsAtom + "}"
 
-        assert feed.find("{%s}title" % nsAtom).text == self.title
-        assert feed.find("{%s}updated" % nsAtom).text is not None
-        assert feed.find("{%s}id" % nsAtom).text == self.feedId
-        assert feed.find("{%s}category" % nsAtom)\
-            .get('term') == self.categoryTerm
-        assert feed.find("{%s}category" % nsAtom)\
-            .get('label') == self.categoryLabel
-        assert feed.find("{%s}author" % nsAtom)\
-            .find("{%s}name" % nsAtom).text == self.authorName
-        assert feed.find("{%s}author" % nsAtom)\
-            .find("{%s}email" % nsAtom).text == self.authorMail
-        assert feed.findall("{%s}link" % nsAtom)[0]\
-            .get('href') == self.linkHref
-        assert feed.findall("{%s}link" % nsAtom)[0].get('rel') == self.linkRel
-        assert feed.findall("{%s}link" % nsAtom)[1]\
-            .get('href') == self.link2Href
-        assert feed.findall("{%s}link" % nsAtom)[1].get('rel') == self.link2Rel
-        assert feed.find("{%s}logo" % nsAtom).text == self.logo
-        assert feed.find("{%s}icon" % nsAtom).text == self.icon
-        assert feed.find("{%s}subtitle" % nsAtom).text == self.subtitle
-        assert feed.find("{%s}contributor" % nsAtom)\
-            .find("{%s}name" % nsAtom).text == self.contributor['name']
-        assert feed.find("{%s}contributor" % nsAtom)\
-            .find("{%s}email" % nsAtom).text == self.contributor['email']
-        assert feed.find("{%s}contributor" % nsAtom)\
-            .find("{%s}uri" % nsAtom).text == self.contributor['uri']
-        assert feed.find("{%s}rights" % nsAtom).text == self.copyright
+        print(nsAtom)
+        print(f"{nsAtom}title")
+        testcases = [
+            (
+                feed.find(f"{nsAtom}title").text,
+                self.title
+            ), (
+                feed.find(f"{nsAtom}id").text,
+                self.feedId
+            ), (
+                feed.find(f"{nsAtom}category").get('term'),
+                self.categoryTerm
+            ), (
+                feed.find(f"{nsAtom}category").get('label'),
+                self.categoryLabel
+            ), (
+                feed.find(f"{nsAtom}author").find(f"{nsAtom}name").text,
+                self.authorName
+            ), (
+                feed.find(f"{nsAtom}author").find(f"{nsAtom}email").text,
+                self.authorMail
+            ), (
+                feed.findall(f"{nsAtom}link")[0].get('href'),
+                self.linkHref
+            ), (
+                feed.findall(f"{nsAtom}link")[0].get('rel'),
+                self.linkRel
+            ), (
+                feed.findall(f"{nsAtom}link")[1].get('href'),
+                self.link2Href
+            ), (
+                feed.findall(f"{nsAtom}link")[1].get('rel'),
+                self.link2Rel
+            ), (
+                feed.find(f"{nsAtom}logo").text,
+                self.logo
+            ), (
+                feed.find(f"{nsAtom}icon").text,
+                self.icon
+            ), (
+                feed.find(f"{nsAtom}subtitle").text,
+                self.subtitle
+            ), (
+                feed.find(f"{nsAtom}contributor").find(f"{nsAtom}name").text,
+                self.contributor['name']
+            ), (
+                feed.find(f"{nsAtom}contributor").find(f"{nsAtom}email").text,
+                self.contributor['email']
+            ), (
+                feed.find(f"{nsAtom}contributor").find(f"{nsAtom}uri").text,
+                self.contributor['uri']
+            ), (
+                feed.find(f"{nsAtom}rights").text,
+                self.copyright
+            )]
+        for actual, expected in testcases:
+            self.assertEqual(actual, expected)
+
+        self.assertIsNot(
+                feed.find(f"{nsAtom}updated").text,
+                None)
 
     def test_rssFeedFile(self):
         fg = self.fg
@@ -301,39 +337,64 @@ class TestSequenceFunctions(unittest.TestCase):
         nsAtom = self.nsAtom
 
         ch = feed.find("channel")
-        assert ch is not None
+        self.assertIsNot(ch, None)
 
-        assert ch.find("title").text == self.title
-        assert ch.find("description").text == self.subtitle
-        assert ch.find("lastBuildDate").text is not None
-        docs = "http://www.rssboard.org/rss-specification"
-        assert ch.find("docs").text == docs
-        assert ch.find("generator").text == "python-feedgen"
-        assert ch.findall("{%s}link" % nsAtom)[0].get('href') == self.link2Href
-        assert ch.findall("{%s}link" % nsAtom)[0].get('rel') == self.link2Rel
-        assert ch.find("image").find("url").text == self.logo
-        assert ch.find("image").find("title").text == self.title
-        assert ch.find("image").find("link").text == self.link2Href
-        assert ch.find("category").text == self.categoryLabel
-        assert ch.find("cloud").get('domain') == self.cloudDomain
-        assert ch.find("cloud").get('port') == self.cloudPort
-        assert ch.find("cloud").get('path') == self.cloudPath
-        assert ch.find("cloud").get('registerProcedure') == \
-            self.cloudRegisterProcedure
-        assert ch.find("cloud").get('protocol') == self.cloudProtocol
-        assert ch.find("copyright").text == self.copyright
-        assert ch.find("docs").text == self.docs
-        assert ch.find("managingEditor").text == self.managingEditor
-        assert ch.find("rating").text == self.rating
-        assert ch.find("skipDays").find("day").text == self.skipDays
-        assert int(ch.find("skipHours").find("hour").text) == self.skipHours
-        assert ch.find("textInput").get('title') == self.textInputTitle
-        assert ch.find("textInput").get('description') == \
-            self.textInputDescription
-        assert ch.find("textInput").get('name') == self.textInputName
-        assert ch.find("textInput").get('link') == self.textInputLink
-        assert int(ch.find("ttl").text) == self.ttl
-        assert ch.find("webMaster").text == self.webMaster
+        self.assertEqual(ch.find("title").text,
+                         self.title)
+        self.assertEqual(ch.find("description").text,
+                         self.subtitle)
+        self.assertIsNot(ch.find("lastBuildDate").text,
+                         None)
+        self.assertEqual(ch.find("docs").text,
+                         "http://www.rssboard.org/rss-specification")
+        self.assertEqual(ch.find("generator").text,
+                         "python-feedgen")
+        self.assertEqual(ch.findall("{%s}link" % nsAtom)[0].get('href'),
+                         self.link2Href)
+        self.assertEqual(ch.findall("{%s}link" % nsAtom)[0].get('rel'),
+                         self.link2Rel)
+        self.assertEqual(ch.find("image").find("url").text,
+                         self.logo)
+        self.assertEqual(ch.find("image").find("title").text,
+                         self.title)
+        self.assertEqual(ch.find("image").find("link").text,
+                         self.link2Href)
+        self.assertEqual(ch.find("category").text,
+                         self.categoryLabel)
+        self.assertEqual(ch.find("cloud").get('domain'),
+                         self.cloudDomain)
+        self.assertEqual(ch.find("cloud").get('port'),
+                         self.cloudPort)
+        self.assertEqual(ch.find("cloud").get('path'),
+                         self.cloudPath)
+        self.assertEqual(ch.find("cloud").get('registerProcedure'),
+                         self.cloudRegisterProcedure)
+        self.assertEqual(ch.find("cloud").get('protocol'),
+                         self.cloudProtocol)
+        self.assertEqual(ch.find("copyright").text,
+                         self.copyright)
+        self.assertEqual(ch.find("docs").text,
+                         self.docs)
+        self.assertEqual(ch.find("managingEditor").text,
+                         self.managingEditor)
+        self.assertEqual(ch.find("rating").text,
+                         self.rating)
+        self.assertEqual(ch.find("skipDays").find("day").text,
+                         self.skipDays)
+        self.assertEqual(int(ch.find("skipHours").find("hour").text),
+                         self.skipHours)
+        self.assertEqual(ch.find("textInput").get('title'),
+                         self.textInputTitle)
+        self.assertEqual(ch.find("textInput").get('description'),
+                         self.textInputDescription)
+        self.assertEqual(ch.find("textInput").get('name'),
+                         self.textInputName)
+        self.assertEqual(ch.find("textInput").get('link'),
+                         self.textInputLink)
+        self.assertEqual(int(ch.find("ttl").text),
+                         self.ttl)
+        self.assertEqual(ch.find("webMaster").text,
+                         self.webMaster)
 
 
 if __name__ == '__main__':

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,19 +16,15 @@ class TestSequenceFunctions(unittest.TestCase):
 
     def test_usage(self):
         sys.argv = ['feedgen']
-        try:
+        with self.assertRaises(SystemExit) as e:
             __main__.main()
-        except BaseException as e:
-            assert e.code is None
+        self.assertEqual(e.exception.code, None)
 
     def test_feed(self):
         for ftype in 'rss', 'atom', 'podcast', 'torrent', 'dc.rss', \
                      'dc.atom', 'syndication.rss', 'syndication.atom':
             sys.argv = ['feedgen', ftype]
-            try:
-                __main__.main()
-            except Exception:
-                assert False
+            __main__.main()
 
     def test_file(self):
         for extemsion in '.atom', '.rss':
@@ -36,7 +32,6 @@ class TestSequenceFunctions(unittest.TestCase):
             sys.argv = ['feedgen', filename]
             try:
                 __main__.main()
-            except Exception:
-                assert False
-            os.close(fh)
-            os.remove(filename)
+            finally:
+                os.close(fh)
+                os.remove(filename)


### PR DESCRIPTION
This patch switches to the assert statements provided by Python's unit
test framework to assure the statements are always executed and produce
proper error messages in case of test failures.