### PR TITLE
Add missing iTunes tags

### DIFF
--- a/feedgen/__main__.py
+++ b/feedgen/__main__.py
@@ -100,6 +100,7 @@ def main():
         fg.podcast.itunes_summary('Lorem ipsum dolor sit amet, consectetur ' +
                                   'adipiscing elit. Verba tu fingas et ea ' +
                                   'dicas, quae non sentias?')
+        fg.podcast.itunes_type('episodic')
         fe.podcast.itunes_author('Lars Kiesow')
         fe.podcast.itunes_season(1)
         fe.podcast.itunes_episode(1)

--- a/feedgen/__main__.py
+++ b/feedgen/__main__.py
@@ -104,6 +104,7 @@ def main():
         fe.podcast.itunes_author('Lars Kiesow')
         fe.podcast.itunes_season(1)
         fe.podcast.itunes_episode(1)
+        fe.podcast.itunes_title('First podcast episode')
         print_enc(fg.rss_str(pretty=True))
 
     elif arg == 'torrent':

--- a/feedgen/__main__.py
+++ b/feedgen/__main__.py
@@ -101,6 +101,8 @@ def main():
                                   'adipiscing elit. Verba tu fingas et ea ' +
                                   'dicas, quae non sentias?')
         fe.podcast.itunes_author('Lars Kiesow')
+        fe.podcast.itunes_season(1)
+        fe.podcast.itunes_episode(1)
         print_enc(fg.rss_str(pretty=True))
 
     elif arg == 'torrent':

--- a/feedgen/__main__.py
+++ b/feedgen/__main__.py
@@ -105,6 +105,7 @@ def main():
         fe.podcast.itunes_season(1)
         fe.podcast.itunes_episode(1)
         fe.podcast.itunes_title('First podcast episode')
+        fe.podcast.itunes_episode_type('full')
         print_enc(fg.rss_str(pretty=True))
 
     elif arg == 'torrent':

--- a/feedgen/ext/podcast.py
+++ b/feedgen/ext/podcast.py
@@ -97,7 +97,7 @@ class PodcastExtension(BaseExtension):
             summary = xml_elem('{%s}summary' % ITUNES_NS, channel)
             summary.text = self.__itunes_summary
 
-        if self.__itunes_type:
+        if self.__itunes_type in ('episodic', 'serial'):
             type = xml_elem('{%s}type' % ITUNES_NS, channel)
             type.text = self.__itunes_type
 

--- a/feedgen/ext/podcast.py
+++ b/feedgen/ext/podcast.py
@@ -32,6 +32,7 @@ class PodcastExtension(BaseExtension):
         self.__itunes_owner = None
         self.__itunes_subtitle = None
         self.__itunes_summary = None
+        self.__itunes_type = None
 
     def extend_ns(self):
         return {'itunes': 'http://www.itunes.com/dtds/podcast-1.0.dtd'}
@@ -95,6 +96,10 @@ class PodcastExtension(BaseExtension):
         if self.__itunes_summary:
             summary = xml_elem('{%s}summary' % ITUNES_NS, channel)
             summary.text = self.__itunes_summary
+
+        if self.__itunes_type:
+            type = xml_elem('{%s}type' % ITUNES_NS, channel)
+            type.text = self.__itunes_type
 
         return rss_feed
 
@@ -317,6 +322,34 @@ class PodcastExtension(BaseExtension):
         if itunes_summary is not None:
             self.__itunes_summary = itunes_summary
         return self.__itunes_summary
+
+    def itunes_type(self, itunes_type=None):
+        '''Get or set the itunes:type value of the podcast. This tag should
+        be used to indicate the type of your podcast.
+        The two values for this tag are "episodic" and "serial".
+
+        If your show is Serial you must use this tag.
+
+        Specify episodic when episodes are intended to be consumed without any
+        specific order. Apple Podcasts will present newest episodes first and
+        display the publish date (required) of each episode. If organized into
+        seasons, the newest season will be presented first - otherwise,
+        episodes will be grouped by year published, newest first.
+
+         Specify serial when episodes are intended to be consumed in sequential
+         order. Apple Podcasts will present the oldest episodes first and
+         display the episode numbers (required) of each episode. If organized
+         into seasons, the newest season will be presented first and
+         <itunes:episode> numbers must be given for each episode.
+
+        :param itunes_type: The type of the podcast
+        :returns: type of the pdocast.
+        '''
+        if itunes_type is not None:
+            if itunes_type not in ('episodic', 'serial'):
+                raise ValueError('Invalid value for type tag')
+            self.__itunes_type = itunes_type
+        return self.__itunes_type
 
     _itunes_categories = {
             'Arts': [

--- a/feedgen/ext/podcast_entry.py
+++ b/feedgen/ext/podcast_entry.py
@@ -32,6 +32,7 @@ class PodcastEntryExtension(BaseEntryExtension):
         self.__itunes_summary = None
         self.__itunes_season = None
         self.__itunes_episode = None
+        self.__itunes_title = None
 
     def extend_rss(self, entry):
         '''Add additional fields to an RSS item.
@@ -87,6 +88,10 @@ class PodcastEntryExtension(BaseEntryExtension):
         if self.__itunes_episode:
             episode = xml_elem('{%s}episode' % ITUNES_NS, entry)
             episode.text = str(self.__itunes_episode)
+
+        if self.__itunes_title:
+            title = xml_elem('{%s}title' % ITUNES_NS, entry)
+            title.text = self.__itunes_title
         return entry
 
     def itunes_author(self, itunes_author=None):
@@ -272,3 +277,17 @@ class PodcastEntryExtension(BaseEntryExtension):
         if itunes_episode is not None:
             self.__itunes_episode = int(itunes_episode)
         return self.__itunes_episode
+
+    def itunes_title(self, itunes_title=None):
+        '''Get or set the itunes:title value for the podcast episode.
+
+        An episode title specific for Apple Podcasts. Don’t specify the episode
+        number or season number in this tag. Also, don’t repeat the title of
+        your show within your episode title.
+
+        :param itunes_title: Episode title specific for Apple Podcasts
+        :returns: Title specific for Apple Podcast
+        '''
+        if itunes_title is not None:
+            self.__itunes_title = itunes_title
+        return self.__itunes_title

--- a/feedgen/ext/podcast_entry.py
+++ b/feedgen/ext/podcast_entry.py
@@ -30,6 +30,8 @@ class PodcastEntryExtension(BaseEntryExtension):
         self.__itunes_order = None
         self.__itunes_subtitle = None
         self.__itunes_summary = None
+        self.__itunes_season = None
+        self.__itunes_episode = None
 
     def extend_rss(self, entry):
         '''Add additional fields to an RSS item.
@@ -77,6 +79,14 @@ class PodcastEntryExtension(BaseEntryExtension):
         if self.__itunes_summary:
             summary = xml_elem('{%s}summary' % ITUNES_NS, entry)
             summary.text = self.__itunes_summary
+
+        if self.__itunes_season:
+            season = xml_elem('{%s}season' % ITUNES_NS, entry)
+            season.text = str(self.__itunes_season)
+
+        if self.__itunes_episode:
+            episode = xml_elem('{%s}episode' % ITUNES_NS, entry)
+            episode.text = str(self.__itunes_episode)
         return entry
 
     def itunes_author(self, itunes_author=None):
@@ -242,3 +252,23 @@ class PodcastEntryExtension(BaseEntryExtension):
         if itunes_summary is not None:
             self.__itunes_summary = itunes_summary
         return self.__itunes_summary
+
+    def itunes_season(self, itunes_season=None):
+        '''Get or set the itunes:season value for the podcast episode.
+
+        :param itunes_season: Season number of the podcast epiosode.
+        :returns: Season number of the podcast episode.
+        '''
+        if itunes_season is not None:
+            self.__itunes_season = int(itunes_season)
+        return self.__itunes_season
+
+    def itunes_episode(self, itunes_episode=None):
+        '''Get or set the itunes:episode value for the podcast episode.
+
+        :param itunes_season: Episode number of the podcast epiosode.
+        :returns: Episode number of the podcast episode.
+        '''
+        if itunes_episode is not None:
+            self.__itunes_episode = int(itunes_episode)
+        return self.__itunes_episode

--- a/feedgen/ext/podcast_entry.py
+++ b/feedgen/ext/podcast_entry.py
@@ -33,6 +33,7 @@ class PodcastEntryExtension(BaseEntryExtension):
         self.__itunes_season = None
         self.__itunes_episode = None
         self.__itunes_title = None
+        self.__itunes_episode_type = None
 
     def extend_rss(self, entry):
         '''Add additional fields to an RSS item.
@@ -92,6 +93,10 @@ class PodcastEntryExtension(BaseEntryExtension):
         if self.__itunes_title:
             title = xml_elem('{%s}title' % ITUNES_NS, entry)
             title.text = self.__itunes_title
+
+        if self.__itunes_episode_type in ('full', 'trailer', 'bonus'):
+            episode_type = xml_elem('{%s}episodeType' % ITUNES_NS, entry)
+            episode_type.text = self.__itunes_episode_type
         return entry
 
     def itunes_author(self, itunes_author=None):
@@ -291,3 +296,26 @@ class PodcastEntryExtension(BaseEntryExtension):
         if itunes_title is not None:
             self.__itunes_title = itunes_title
         return self.__itunes_title
+
+    def itunes_episode_type(self, itunes_episode_type=None):
+        '''Get or set the itunes:episodeType value of the item. This tag should
+        be used to indicate the episode type.
+        The three values for this tag are "full", "trailer" and "bonus".
+
+        If an episode is a trailer or bonus content, use this tag.
+
+        Specify full when you are submitting the complete content of your show.
+        Specify trailer when you are submitting a short, promotional piece of
+        content that represents a preview of your current show.
+        Specify bonus when you are submitting extra content for your show (for
+        example, behind the scenes information or interviews with the cast) or
+        cross-promotional content for another show.
+
+        :param itunes_episode_type: The episode type
+        :returns: type of the episode.
+        '''
+        if itunes_episode_type is not None:
+            if itunes_episode_type not in ('full', 'trailer', 'bonus'):
+                raise ValueError('Invalid value for episodeType tag')
+            self.__itunes_episode_type = itunes_episode_type
+        return self.__itunes_episode_type

--- a/tests/test_extensions/test_podcast.py
+++ b/tests/test_extensions/test_podcast.py
@@ -82,6 +82,7 @@ class TestExtensionPodcast(unittest.TestCase):
         fe.podcast.itunes_summary('x')
         fe.podcast.itunes_season(1)
         fe.podcast.itunes_episode(1)
+        fe.podcast.itunes_title('Podcast Title')
         assert fe.podcast.itunes_author() == 'Lars Kiesow'
         assert fe.podcast.itunes_block() == 'x'
         assert fe.podcast.itunes_duration() == '00:01:30'
@@ -93,6 +94,7 @@ class TestExtensionPodcast(unittest.TestCase):
         assert fe.podcast.itunes_summary() == 'x'
         assert fe.podcast.itunes_season() == 1
         assert fe.podcast.itunes_episode() == 1
+        assert fe.podcast.itunes_title() == 'Podcast Title'
 
         # Check that we have the item in the resulting XML
         ns = {'itunes': 'http://www.itunes.com/dtds/podcast-1.0.dtd'}

--- a/tests/test_extensions/test_podcast.py
+++ b/tests/test_extensions/test_podcast.py
@@ -52,6 +52,7 @@ class TestExtensionPodcast(unittest.TestCase):
         fg.podcast.itunes_image('x.png')
         fg.podcast.itunes_subtitle('x')
         fg.podcast.itunes_summary('x')
+        fg.podcast.itunes_type('episodic')
         assert fg.podcast.itunes_author() == 'Lars Kiesow'
         assert fg.podcast.itunes_block() == 'x'
         assert fg.podcast.itunes_complete() == 'no'
@@ -59,6 +60,7 @@ class TestExtensionPodcast(unittest.TestCase):
         assert fg.podcast.itunes_image() == 'x.png'
         assert fg.podcast.itunes_subtitle() == 'x'
         assert fg.podcast.itunes_summary() == 'x'
+        assert fg.podcast.itunes_type() == 'episodic'
 
         # Check that we have the item in the resulting XML
         ns = {'itunes': 'http://www.itunes.com/dtds/podcast-1.0.dtd'}

--- a/tests/test_extensions/test_podcast.py
+++ b/tests/test_extensions/test_podcast.py
@@ -78,6 +78,8 @@ class TestExtensionPodcast(unittest.TestCase):
         fe.podcast.itunes_order(1)
         fe.podcast.itunes_subtitle('x')
         fe.podcast.itunes_summary('x')
+        fe.podcast.itunes_season(1)
+        fe.podcast.itunes_episode(1)
         assert fe.podcast.itunes_author() == 'Lars Kiesow'
         assert fe.podcast.itunes_block() == 'x'
         assert fe.podcast.itunes_duration() == '00:01:30'
@@ -87,6 +89,8 @@ class TestExtensionPodcast(unittest.TestCase):
         assert fe.podcast.itunes_order() == 1
         assert fe.podcast.itunes_subtitle() == 'x'
         assert fe.podcast.itunes_summary() == 'x'
+        assert fe.podcast.itunes_season() == 1
+        assert fe.podcast.itunes_episode() == 1
 
         # Check that we have the item in the resulting XML
         ns = {'itunes': 'http://www.itunes.com/dtds/podcast-1.0.dtd'}

--- a/tests/test_extensions/test_podcast.py
+++ b/tests/test_extensions/test_podcast.py
@@ -83,6 +83,7 @@ class TestExtensionPodcast(unittest.TestCase):
         fe.podcast.itunes_season(1)
         fe.podcast.itunes_episode(1)
         fe.podcast.itunes_title('Podcast Title')
+        fe.podcast.itunes_episode_type('full')
         assert fe.podcast.itunes_author() == 'Lars Kiesow'
         assert fe.podcast.itunes_block() == 'x'
         assert fe.podcast.itunes_duration() == '00:01:30'
@@ -95,6 +96,7 @@ class TestExtensionPodcast(unittest.TestCase):
         assert fe.podcast.itunes_season() == 1
         assert fe.podcast.itunes_episode() == 1
         assert fe.podcast.itunes_title() == 'Podcast Title'
+        assert fe.podcast.itunes_episode_type() == 'full'
 
         # Check that we have the item in the resulting XML
         ns = {'itunes': 'http://www.itunes.com/dtds/podcast-1.0.dtd'}


### PR DESCRIPTION
Adds the ability to have season and episode tags as described in the [iTunes specification](https://help.apple.com/itc/podcasts_connect/#/itcb54353390).

This adresses _item/itunes:episode_ of #96.