### PR TITLE
FeedGenerator: Fix pubDate documentation to not set `updated` timestamps

### DIFF
--- a/feedgen/feed.py
+++ b/feedgen/feed.py
@@ -880,8 +880,6 @@ class FeedGenerator(object):
         a datetime.datetime object. In any case it is necessary that the value
         include timezone information.
 
-        This will set both atom:updated and rss:lastBuildDate.
-
         :param pubDate: The publication date.
         :returns: Publication date as datetime.datetime
         '''


### PR DESCRIPTION
The documentation stated that atom:updated and rss:lastBuildDate would get
updated, which they don't. It seems this was a copy/paste error from the
documentation of the `updated` or `lastBuildDate` methods.