### PR TITLE
Fix issue where "CDATA" was incorrectly used as content type in atom entries

### DIFF
--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -54,7 +54,7 @@ def _add_text_elm(entry, data, name):
             )
     # Add type description of the content
     if type_:
-        elm.attrib['type'] = type_
+        elm.attrib['type'] = 'html' if type_ == 'CDATA' else type_
 
 
 class FeedEntry(object):

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -163,7 +163,7 @@ class TestSequenceFunctions(unittest.TestCase):
         fe.title('some title')
         fe.content('content', type='CDATA')
         result = fg.atom_str()
-        assert b'<content type="CDATA"><![CDATA[content]]></content>' in result
+        assert b'<content type="html"><![CDATA[content]]></content>' in result
 
     def test_summary_html_type(self):
         fg = FeedGenerator()


### PR DESCRIPTION
According to the [Atom specification](https://validator.w3.org/feed/docs/atom.html), the acceptable values for the type of  `<content>`  are `text`, `html`, and `xhtml`. 
This PR fixes the previous code that incorrectly used `CDATA` as the type value.