### PR TITLE
Fix etree to string conversion in FeedGenerator

### DIFF
--- a/feedgen/feed.py
+++ b/feedgen/feed.py
@@ -220,7 +220,7 @@ class FeedGenerator(object):
         <https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring>`_
         '''
         feed, doc = self._create_atom(extensions=extensions)
-        return etree.tostring(feed, pretty_print=pretty, encoding=encoding,
+        return etree.tostring(doc, pretty_print=pretty, encoding=encoding,
                               xml_declaration=xml_declaration)
 
     def atom_file(self, filename, extensions=True, pretty=False,
@@ -396,7 +396,7 @@ class FeedGenerator(object):
         <https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring>`_
         '''
         feed, doc = self._create_rss(extensions=extensions)
-        return etree.tostring(feed, pretty_print=pretty, encoding=encoding,
+        return etree.tostring(doc, pretty_print=pretty, encoding=encoding,
                               xml_declaration=xml_declaration)
 
     def rss_file(self, filename, extensions=True, pretty=False,


### PR DESCRIPTION
When converting `feed` object to a string, using `atom_str` or `rss_str` methods, with `etree.tostring` method, `feed` instead of `doc` is supplied. In this case, changes applied outside the <rss> was lost (e.g., adding a processing instruction `<?xml-stylesheet href="rss.xsl" type="text/xsl"?>` as sibling to `<rss>`).

The `feed` object has now been replaced by the `doc` object in both the `_create_atom` and `_create_rss` methods, ensuring the correct conversion and preventing possible lost of information in the feed generation.