### PR TITLE
Allow integer to be used for enclosure length

### DIFF
--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -668,7 +668,7 @@ class FeedEntry(object):
         :returns: Data of the enclosure element.
         '''
         if url is not None:
-            self.link(href=url, rel='enclosure', type=type, length=length)
+            self.link(href=url, rel='enclosure', type=type, length=str(length))
         return self.__rss_enclosure
 
     def ttl(self, ttl=None):


### PR DESCRIPTION
This patch allows integer to be used for specifying the enclosure length instead of just allowing string values. This is certainly the more natural choice for something representing a number.

With this patch string values will continue to work.

This fixes #104