### PR TITLE
Fixex generating Atom feed when adding description as summary

### DIFF
--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -499,7 +499,7 @@ class FeedEntry(object):
         if description is not None:
             self.__rss_description = description
             if isSummary:
-                self.__atom_summary = description
+                self.__atom_summary = {'summary': description}
             else:
                 self.__atom_content = {'content': description}
         return self.__rss_description


### PR DESCRIPTION
This patch fixes the problem that generating an Atom feed fails when adding an RSS description marked as summary. The problem was that feedgen internally expected a dictionary, but the value was stored as a string in this case.

This fixes #94