### PR TITLE
Update RPM Specfile (tests, pypi, py3)

### DIFF
--- a/python-feedgen.spec
+++ b/python-feedgen.spec
@@ -1,38 +1,24 @@
 %global pypi_name feedgen
+%global pypi_version 1.0.0
 
 Name:           python-%{pypi_name}
-Version:        0.9.0
+Version:        %{pypi_version}
 Release:        1%{?dist}
 Summary:        Feed Generator (ATOM, RSS, Podcasts)
 
 License:        BSD or LGPLv3
 URL:            http://lkiesow.github.io/python-feedgen
-Source0:        https://github.com/lkiesow/%{name}/archive/v%{version}.tar.gz
+#Source0:        https://github.com/lkiesow/%{name}/archive/v%{version}.tar.gz
+Source0:        %{pypi_source}
 BuildArch:      noarch
 
-BuildRequires:  python2-dateutil
-BuildRequires:  python2-devel
-BuildRequires:  python2-lxml
-BuildRequires:  python2-setuptools
-
-BuildRequires:  python3-dateutil
 BuildRequires:  python3-devel
-BuildRequires:  python3-lxml
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(lxml)
+BuildRequires:  python3dist(python-dateutil)
 
 %description
-Feedgenerator This module can be used to generate web feeds in both ATOM and
-RSS format. It has support for extensions. Included is for example an extension
-to produce Podcasts.
-
-%package -n     python2-%{pypi_name}
-Summary:        %{summary}
-%{?python_provide:%python_provide python2-%{pypi_name}}
-
-Requires:       python2-dateutil
-Requires:       python2-lxml
-%description -n python2-%{pypi_name}
-Feedgenerator This module can be used to generate web feeds in both ATOM and
+Feedgenerator: This module can be used to generate web feeds in both ATOM and
 RSS format. It has support for extensions. Included is for example an extension
 to produce Podcasts.
 
@@ -40,37 +26,28 @@ to produce Podcasts.
 Summary:        %{summary}
 %{?python_provide:%python_provide python3-%{pypi_name}}
 
-Requires:       python3-dateutil
-Requires:       python3-lxml
+Requires:       python3dist(python-dateutil)
+Requires:       python3dist(lxml)
+
 %description -n python3-%{pypi_name}
-Feedgenerator This module can be used to generate web feeds in both ATOM and
+Feedgenerator: This module can be used to generate web feeds in both ATOM and
 RSS format. It has support for extensions. Included is for example an extension
 to produce Podcasts.
 
 
 %prep
-%autosetup
+%autosetup -n %{pypi_name}-%{pypi_version}
 # Remove bundled egg-info
 rm -rf %{pypi_name}.egg-info
 
 %build
-%py2_build
 %py3_build
 
 %install
-%py2_install
 %py3_install
 
-
 %check
-%{__python2} setup.py test
 %{__python3} setup.py test
-
-%files -n python2-%{pypi_name}
-%license license.lgpl license.bsd
-%doc readme.rst
-%{python2_sitelib}/%{pypi_name}
-%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
 
 %files -n python3-%{pypi_name}
 %license license.lgpl license.bsd
@@ -79,6 +56,10 @@ rm -rf %{pypi_name}.egg-info
 %{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
 
 %changelog
+* Mon Dec 25 2023 Lars Kiesow <lkiesow@uos.de> - 1.0.0-1
+- Update to 1.0.0
+- Removing support for Python 2
+
 * Sat May 19 2018 Lars Kiesow <lkiesow@uos.de> - 0.7.0-1
 - Update to 0.7.0
 


### PR DESCRIPTION
This patch updates the RPM specfile to make sure it uses modern macros used for Python packaging. It also switches to the tarballs published on PyPi which will include the tests in future versions. Finally, this drops support of Python 2 which has reached end of life quite a while ago.