### PR TITLE
Fix handling of links in atom feeds

### DIFF
--- a/feedgen/entry.py
+++ b/feedgen/entry.py
@@ -137,17 +137,17 @@ class FeedEntry(object):
         _add_text_elm(entry, self.__atom_content, 'content')
 
         for link in self.__atom_link or []:
-            link = xml_elem('link', entry, href=link['href'])
+            linkelm = xml_elem('link', entry, href=link['href'])
             if link.get('rel'):
-                link.attrib['rel'] = link['rel']
+                linkelm.attrib['rel'] = link['rel']
             if link.get('type'):
-                link.attrib['type'] = link['type']
+                linkelm.attrib['type'] = link['type']
             if link.get('hreflang'):
-                link.attrib['hreflang'] = link['hreflang']
+                linkelm.attrib['hreflang'] = link['hreflang']
             if link.get('title'):
-                link.attrib['title'] = link['title']
+                linkelm.attrib['title'] = link['title']
             if link.get('length'):
-                link.attrib['length'] = link['length']
+                linkelm.attrib['length'] = link['length']
 
         _add_text_elm(entry, self.__atom_summary, 'summary')
 


### PR DESCRIPTION
The existing code iterated over entry links like this:

    for link in self.__atom_link or []:
        link = xml_elem('link', entry, href=link['href'])

The first line in the loop overwrites the `link` variable, rendering the
rest of the loop a no-op. This commit corrects the situation by creating a
new variable rather than overwriting the loop variable.
